### PR TITLE
Added parameters link to sqlRecipients

### DIFF
--- a/frontend/packages/system/src/Recipients/SqlRecipientLists/DetailEdit.tsx
+++ b/frontend/packages/system/src/Recipients/SqlRecipientLists/DetailEdit.tsx
@@ -2,10 +2,12 @@ import React, { useEffect } from 'react';
 import { useTranslation } from '@common/intl';
 import {
   useBreadcrumbs,
+  useDetailPanel,
   useNotification,
   useQueryParamsState,
 } from '@common/hooks';
 import {
+  AppBarButtonsPortal,
   AppBarContentPortal,
   BasicSpinner,
   Box,
@@ -44,6 +46,7 @@ export const DetailEdit = () => {
   const urlParams = useParams();
   const { suffix, setSuffix } = useBreadcrumbs();
   const { error } = useNotification();
+  const { OpenButton } = useDetailPanel(t('label.parameters'));
 
   const { queryParams } = useQueryParamsState({
     initialFilter: { id: { equalTo: urlParams['listId'] } },
@@ -96,6 +99,7 @@ export const DetailEdit = () => {
 
   return (
     <>
+      <AppBarButtonsPortal>{OpenButton}</AppBarButtonsPortal>
       {/* Description/Details section */}
       <AppBarContentPortal sx={{ paddingBottom: '16px', flex: 1 }}>
         <Paper

--- a/frontend/packages/system/src/Recipients/SqlRecipientLists/RecipientQueryEditor.tsx
+++ b/frontend/packages/system/src/Recipients/SqlRecipientLists/RecipientQueryEditor.tsx
@@ -218,6 +218,8 @@ export const RecipientQueryEditor = ({
                 {TeraUtils.extractParams(draft.query).join(', ')}
               </Typography>
               <IconButton
+                height="24px"
+                width="24px"
                 onClick={openSidePanel}
                 icon={<EditIcon />}
                 label={t('label.edit')}


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Closes #142 

# 👩🏻‍💻 What does this PR do?
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->
Adds a parameters button to top of sql recipients screen

# 🧪 How has/should this change been tested?
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->


Check that the parameters button shows at the top right hand side of the SQL recipients page.
Test that parameters panel can be re-opened if closed by the user.

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

