### PR TITLE
Parse recipient_ids & lists into their own fields

### DIFF
--- a/backend/graphql/notification_config/src/mutations/mod.rs
+++ b/backend/graphql/notification_config/src/mutations/mod.rs
@@ -29,7 +29,8 @@ pub fn map_error(error: ModifyNotificationConfigError) -> Result<ModifyNotificat
         }
         ModifyNotificationConfigError::ModifiedRecordNotFound => InternalError(formatted_error),
         ModifyNotificationConfigError::DatabaseError(_) => InternalError(formatted_error),
-        ModifyNotificationConfigError::GenericError(s) => InternalError(s),
+        ModifyNotificationConfigError::InternalError(s) => InternalError(s),
+        ModifyNotificationConfigError::BadUserInput(s) => BadUserInput(s),
     };
 
     Err(graphql_error.extend())

--- a/backend/graphql/notification_config/src/mutations/update.rs
+++ b/backend/graphql/notification_config/src/mutations/update.rs
@@ -15,6 +15,9 @@ pub struct UpdateNotificationConfigInput {
     pub configuration_data: Option<String>,
     pub parameters: Option<String>,
     pub status: Option<ConfigStatus>,
+    pub recipient_ids: Option<Vec<String>>,
+    pub recipient_list_ids: Option<Vec<String>>,
+    pub sql_recipient_list_ids: Option<Vec<String>>,
 }
 
 pub fn update_notification_config(
@@ -49,6 +52,9 @@ impl From<UpdateNotificationConfigInput> for UpdateNotificationConfig {
             configuration_data,
             status,
             parameters,
+            recipient_ids,
+            recipient_list_ids,
+            sql_recipient_list_ids,
         }: UpdateNotificationConfigInput,
     ) -> Self {
         UpdateNotificationConfig {
@@ -57,6 +63,9 @@ impl From<UpdateNotificationConfigInput> for UpdateNotificationConfig {
             configuration_data,
             status: status.map(ConfigStatus::to_domain),
             parameters,
+            recipient_ids,
+            recipient_list_ids,
+            sql_recipient_list_ids,
         }
     }
 }

--- a/backend/graphql/types/src/types/notification_config.rs
+++ b/backend/graphql/types/src/types/notification_config.rs
@@ -1,9 +1,9 @@
 use super::{dataloader::DataLoader, LogNode};
 use async_graphql::{Context, Enum, Object, SimpleObject, Union};
 use graphql_core::{loader::AuditLogLoader, simple_generic_errors::NodeError, ContextExt};
-use repository::{NotificationConfig, NotificationConfigKind, NotificationConfigStatus};
+use repository::{NotificationConfigKind, NotificationConfigStatus};
 use serde::Serialize;
-use service::ListResult;
+use service::{notification_config::query::NotificationConfig, ListResult};
 use util::usize_to_u32;
 
 #[derive(Union)]
@@ -42,6 +42,18 @@ impl NotificationConfigNode {
 
     pub async fn parameters(&self) -> &str {
         &self.row().parameters
+    }
+
+    pub async fn recipient_ids(&self) -> &[String] {
+        &self.row().recipient_ids
+    }
+
+    pub async fn recipient_list_ids(&self) -> &[String] {
+        &self.row().recipient_list_ids
+    }
+
+    pub async fn sql_recipient_list_ids(&self) -> &[String] {
+        &self.row().sql_recipient_list_ids
     }
 
     pub async fn audit_logs(

--- a/backend/repository/migrations/2023-09-25-031335_recipient-notification-config/down.sql
+++ b/backend/repository/migrations/2023-09-25-031335_recipient-notification-config/down.sql
@@ -1,0 +1,1 @@
+-- This file should undo anything in `up.sql`

--- a/backend/repository/migrations/2023-09-25-031335_recipient-notification-config/up.sql
+++ b/backend/repository/migrations/2023-09-25-031335_recipient-notification-config/up.sql
@@ -1,0 +1,4 @@
+-- Your SQL goes here
+ALTER TABLE notification_config ADD COLUMN recipient_ids TEXT NOT NULL default '[]';
+ALTER TABLE notification_config ADD COLUMN recipient_list_ids TEXT NOT NULL default '[]';
+ALTER TABLE notification_config ADD COLUMN sql_recipient_list_ids TEXT NOT NULL default '[]';

--- a/backend/repository/src/db_diesel/notification_config.rs
+++ b/backend/repository/src/db_diesel/notification_config.rs
@@ -7,12 +7,11 @@ use super::{
 use crate::{
     diesel_macros::{apply_equal_filter, apply_sort_no_case, apply_string_filter},
     repository_error::RepositoryError,
-    EqualFilter, NotificationConfigKind, NotificationConfigRow, Pagination, Sort, StringFilter, NotificationConfigStatus, 
+    EqualFilter, NotificationConfigKind, NotificationConfigRow, NotificationConfigStatus,
+    Pagination, Sort, StringFilter,
 };
 
 use diesel::{dsl::IntoBoxed, prelude::*};
-
-pub type NotificationConfig = NotificationConfigRow;
 
 #[derive(Clone, Default, Debug, PartialEq)]
 pub struct NotificationConfigFilter {
@@ -48,14 +47,14 @@ impl<'a> NotificationConfigRepository<'a> {
     pub fn query_by_filter(
         &self,
         filter: NotificationConfigFilter,
-    ) -> Result<Vec<NotificationConfig>, RepositoryError> {
+    ) -> Result<Vec<NotificationConfigRow>, RepositoryError> {
         self.query(Pagination::new(), Some(filter), None)
     }
 
     pub fn query_one(
         &self,
         filter: NotificationConfigFilter,
-    ) -> Result<Option<NotificationConfig>, RepositoryError> {
+    ) -> Result<Option<NotificationConfigRow>, RepositoryError> {
         Ok(self.query_by_filter(filter)?.pop())
     }
 
@@ -64,7 +63,7 @@ impl<'a> NotificationConfigRepository<'a> {
         pagination: Pagination,
         filter: Option<NotificationConfigFilter>,
         sort: Option<NotificationConfigSort>,
-    ) -> Result<Vec<NotificationConfig>, RepositoryError> {
+    ) -> Result<Vec<NotificationConfigRow>, RepositoryError> {
         let mut query = create_filtered_query(filter);
 
         if let Some(sort) = sort {
@@ -81,7 +80,7 @@ impl<'a> NotificationConfigRepository<'a> {
             .offset(pagination.offset as i64)
             .limit(pagination.limit as i64);
 
-        let result = final_query.load::<NotificationConfig>(&self.connection.connection)?;
+        let result = final_query.load::<NotificationConfigRow>(&self.connection.connection)?;
         Ok(result)
     }
 }

--- a/backend/repository/src/db_diesel/notification_config_row.rs
+++ b/backend/repository/src/db_diesel/notification_config_row.rs
@@ -14,6 +14,9 @@ table! {
         configuration_data -> Text,
         status -> crate::db_diesel::notification_config_row::NotificationConfigStatusMapping,
         parameters -> Text,
+        recipient_ids -> Text,
+        recipient_list_ids -> Text,
+        sql_recipient_list_ids -> Text,
         last_run_datetime -> Nullable<Timestamp>,
         next_due_datetime -> Nullable<Timestamp>,
     }
@@ -82,7 +85,10 @@ pub struct NotificationConfigRow {
     // it would appear the diesel JSON types are only available if the postgres feature is enabled...
     pub configuration_data: String,
     pub status: NotificationConfigStatus,
-    pub parameters: String,
+    pub parameters: String,             // JSON object {key: "value"}
+    pub recipient_ids: String,          // JSON array of strings (ids)
+    pub recipient_list_ids: String,     // JSON array of strings (ids)
+    pub sql_recipient_list_ids: String, // JSON array of strings (ids)
     pub last_run_datetime: Option<NaiveDateTime>,
     pub next_due_datetime: Option<NaiveDateTime>,
 }
@@ -143,5 +149,22 @@ impl<'a> NotificationConfigRowRepository<'a> {
             )
             .load::<NotificationConfigRow>(&self.connection.connection)?;
         Ok(result)
+    }
+
+    pub fn set_next_due_by_id(
+        &self,
+        id: &str,
+        last_run: Option<NaiveDateTime>,
+        next_due: Option<NaiveDateTime>,
+    ) -> Result<(), RepositoryError> {
+        let query = diesel::update(notification_config_dsl::notification_config)
+            .filter(notification_config_dsl::id.eq(id))
+            .set((
+                notification_config_dsl::next_due_datetime.eq(next_due),
+                notification_config_dsl::last_run_datetime.eq(last_run),
+            ));
+
+        query.execute(&self.connection.connection)?;
+        Ok(())
     }
 }

--- a/backend/scheduled/src/process.rs
+++ b/backend/scheduled/src/process.rs
@@ -1,10 +1,8 @@
 use chrono::{DateTime, NaiveDateTime, Utc};
-use repository::{
-    NotificationConfigKind, NotificationConfigRow, NotificationConfigRowRepository,
-    NotificationType,
-};
+use repository::{NotificationConfigKind, NotificationConfigRowRepository, NotificationType};
 use service::{
     notification::enqueue::{create_notification_events, NotificationContext, NotificationTarget},
+    notification_config::query::NotificationConfig,
     service_provider::ServiceContext,
 };
 
@@ -65,7 +63,7 @@ enum ProcessingResult {
 
 fn try_process_scheduled_notifications(
     ctx: &ServiceContext,
-    scheduled_notification: NotificationConfigRow,
+    scheduled_notification: NotificationConfig,
     now: NaiveDateTime,
 ) -> Result<ProcessingResult, NotificationError> {
     // Load the notification config
@@ -80,11 +78,11 @@ fn try_process_scheduled_notifications(
     // Update the last_checked time and next_check time
     // We do this before checking if the notification is due so that if the notification is skipped, we still set a good next check time
     NotificationConfigRowRepository::new(&ctx.connection)
-        .update_one(&NotificationConfigRow {
-            last_run_datetime: Some(now),
-            next_due_datetime: Some(next_due_datetime.naive_utc()),
-            ..scheduled_notification.clone()
-        })
+        .set_next_due_by_id(
+            &scheduled_notification.id,
+            Some(now),
+            Some(next_due_datetime.naive_utc()),
+        )
         .map_err(|e| NotificationError::InternalError(format!("{:?}", e)))?;
 
     // Should notification run ?

--- a/backend/service/src/notification_config/create.rs
+++ b/backend/service/src/notification_config/create.rs
@@ -1,13 +1,14 @@
 use chrono::Utc;
 use repository::{
-    LogType, NotificationConfig, NotificationConfigKind, NotificationConfigRow,
-    NotificationConfigRowRepository, StorageConnection, NotificationConfigStatus, 
+    LogType, NotificationConfigKind, NotificationConfigRow, NotificationConfigRowRepository,
+    NotificationConfigStatus, StorageConnection,
 };
 
 use crate::{audit_log::audit_log_entry, service_provider::ServiceContext};
 
 use super::{
-    query::get_notification_config, validate::check_notification_config_does_not_exist,
+    query::{get_notification_config, NotificationConfig},
+    validate::check_notification_config_does_not_exist,
     ModifyNotificationConfigError,
 };
 
@@ -65,6 +66,9 @@ pub fn generate(
         configuration_data: "{}".to_string(),
         status: NotificationConfigStatus::Disabled,
         parameters: "{}".to_string(),
+        recipient_ids: "[]".to_string(),
+        recipient_list_ids: "[]".to_string(),
+        sql_recipient_list_ids: "[]".to_string(),
         last_run_datetime: None,
         next_due_datetime: None,
     })

--- a/backend/service/src/notification_config/mod.rs
+++ b/backend/service/src/notification_config/mod.rs
@@ -1,7 +1,7 @@
 use chrono::NaiveDateTime;
 use repository::{
-    NotificationConfig, NotificationConfigFilter, NotificationConfigKind, NotificationConfigSort,
-    PaginationOption, RepositoryError,
+    NotificationConfigFilter, NotificationConfigKind, NotificationConfigSort, PaginationOption,
+    RepositoryError,
 };
 
 use crate::{service_provider::ServiceContext, ListError, ListResult, SingleRecordError};
@@ -10,8 +10,7 @@ use self::{
     create::{create_notification_config, CreateNotificationConfig},
     delete::{delete_notification_config, DeleteNotificationConfigError},
     query::{
-        get_notification_config, get_notification_configs,
-        get_notification_configs_by_kind_and_next_check_date,
+        find_all_due_by_kind, get_notification_config, get_notification_configs, NotificationConfig,
     },
     update::{update_notification_config, UpdateNotificationConfig},
 };
@@ -31,7 +30,7 @@ pub trait NotificationConfigServiceTrait: Sync + Send {
         kind: NotificationConfigKind,
         datetime: NaiveDateTime,
     ) -> Result<Vec<NotificationConfig>, ListError> {
-        get_notification_configs_by_kind_and_next_check_date(ctx, kind, datetime)
+        find_all_due_by_kind(ctx, kind, datetime)
     }
 
     fn get_notification_configs(
@@ -86,7 +85,8 @@ pub enum ModifyNotificationConfigError {
     ModifiedRecordNotFound,
     DatabaseError(RepositoryError),
     NotificationConfigDoesNotExist,
-    GenericError(String),
+    InternalError(String),
+    BadUserInput(String),
 }
 
 // PartialEq is only needed for tests

--- a/backend/service/src/notification_config/query.rs
+++ b/backend/service/src/notification_config/query.rs
@@ -1,7 +1,8 @@
 use chrono::NaiveDateTime;
 use repository::{
     EqualFilter, NotificationConfigFilter, NotificationConfigKind, NotificationConfigRepository,
-    NotificationConfigRowRepository, NotificationConfigSort, PaginationOption,
+    NotificationConfigRow, NotificationConfigRowRepository, NotificationConfigSort,
+    NotificationConfigStatus, PaginationOption,
 };
 use util::i64_to_u32;
 
@@ -10,10 +11,42 @@ use crate::{
     SingleRecordError,
 };
 
-use super::NotificationConfig;
-
 pub const MAX_LIMIT: u32 = 1000;
 pub const MIN_LIMIT: u32 = 1;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct NotificationConfig {
+    pub id: String,
+    pub title: String,
+    pub kind: NotificationConfigKind,
+    pub configuration_data: String,
+    pub status: NotificationConfigStatus,
+    pub parameters: String,
+    pub recipient_ids: Vec<String>,
+    pub recipient_list_ids: Vec<String>,
+    pub sql_recipient_list_ids: Vec<String>,
+    pub last_run_datetime: Option<NaiveDateTime>,
+    pub next_due_datetime: Option<NaiveDateTime>,
+}
+
+impl From<NotificationConfigRow> for NotificationConfig {
+    fn from(row: NotificationConfigRow) -> Self {
+        NotificationConfig {
+            id: row.id,
+            title: row.title,
+            kind: row.kind,
+            configuration_data: row.configuration_data,
+            status: row.status,
+            parameters: row.parameters,
+            recipient_ids: serde_json::from_str(&row.recipient_ids).unwrap_or_default(),
+            recipient_list_ids: serde_json::from_str(&row.recipient_list_ids).unwrap_or_default(),
+            sql_recipient_list_ids: serde_json::from_str(&row.sql_recipient_list_ids)
+                .unwrap_or_default(),
+            last_run_datetime: row.last_run_datetime,
+            next_due_datetime: row.next_due_datetime,
+        }
+    }
+}
 
 pub fn get_notification_configs(
     ctx: &ServiceContext,
@@ -24,8 +57,10 @@ pub fn get_notification_configs(
     let pagination = get_default_pagination(pagination, MAX_LIMIT, MIN_LIMIT)?;
     let repository = NotificationConfigRepository::new(&ctx.connection);
 
+    let rows = repository.query(pagination, filter.clone(), sort)?;
+
     Ok(ListResult {
-        rows: repository.query(pagination, filter.clone(), sort)?,
+        rows: rows.into_iter().map(|row| row.into()).collect(),
         count: i64_to_u32(repository.count(filter)?),
     })
 }
@@ -40,13 +75,13 @@ pub fn get_notification_config(
         .query_by_filter(NotificationConfigFilter::new().id(EqualFilter::equal_to(&id)))?;
 
     if let Some(record) = result.pop() {
-        Ok(record)
+        Ok(record.into())
     } else {
         Err(SingleRecordError::NotFound(id))
     }
 }
 
-pub fn get_notification_configs_by_kind_and_next_check_date(
+pub fn find_all_due_by_kind(
     ctx: &ServiceContext,
     kind: NotificationConfigKind,
     datetime: NaiveDateTime,
@@ -54,5 +89,5 @@ pub fn get_notification_configs_by_kind_and_next_check_date(
     let repository = NotificationConfigRowRepository::new(&ctx.connection);
     let result = repository.find_all_due_by_kind(kind, datetime)?;
 
-    Ok(result)
+    Ok(result.into_iter().map(|row| row.into()).collect())
 }

--- a/backend/service/src/notification_config/tests/query.rs
+++ b/backend/service/src/notification_config/tests/query.rs
@@ -269,7 +269,7 @@ mod notification_config_query_test {
         let service = &context.service_provider.notification_config_service;
 
         // Create a notification config
-        let config = NotificationConfigRow {
+        let mut config = NotificationConfigRow {
             id: uuid(),
             title: "test".to_string(),
             kind: mock_data["base"].notification_configs[0].kind.clone(),
@@ -290,7 +290,6 @@ mod notification_config_query_test {
 
         // set the last check date to now
         // and next check to 1 hour from now
-        let mut config = result[0].clone();
         config.last_run_datetime = Some(Utc::now().naive_utc());
         config.next_due_datetime = Some(Utc::now().naive_utc() + chrono::Duration::hours(1));
         repo.update_one(&config).unwrap();

--- a/frontend/packages/common/src/types/schema.ts
+++ b/frontend/packages/common/src/types/schema.ts
@@ -541,6 +541,9 @@ export type NotificationConfigNode = {
   id: Scalars['String']['output'];
   kind: ConfigKind;
   parameters: Scalars['String']['output'];
+  recipientIds: Array<Scalars['String']['output']>;
+  recipientListIds: Array<Scalars['String']['output']>;
+  sqlRecipientListIds: Array<Scalars['String']['output']>;
   status: ConfigStatus;
   title: Scalars['String']['output'];
 };
@@ -746,6 +749,9 @@ export type UpdateNotificationConfigInput = {
   configurationData?: InputMaybe<Scalars['String']['input']>;
   id: Scalars['String']['input'];
   parameters?: InputMaybe<Scalars['String']['input']>;
+  recipientIds?: InputMaybe<Array<Scalars['String']['input']>>;
+  recipientListIds?: InputMaybe<Array<Scalars['String']['input']>>;
+  sqlRecipientListIds?: InputMaybe<Array<Scalars['String']['input']>>;
   status?: InputMaybe<ConfigStatus>;
   title?: InputMaybe<Scalars['String']['input']>;
 };

--- a/frontend/packages/system/src/Notifications/Pages/ColdChain/parseConfig.ts
+++ b/frontend/packages/system/src/Notifications/Pages/ColdChain/parseConfig.ts
@@ -36,10 +36,10 @@ export function parseColdChainNotificationConfig(
       reminderInterval,
       reminderUnits,
       locationIds,
-      recipientIds,
-      recipientListIds,
+      recipientIds: recipientIds ?? config.recipientIds,
+      recipientListIds: recipientListIds ?? config.recipientListIds,
+      sqlRecipientListIds: sqlRecipientListIds ?? config.sqlRecipientListIds,
       status: config.status,
-      sqlRecipientListIds,
       parameters: config.parameters,
       parsedParameters: TeraUtils.keyedParamsFromTeraJson(config.parameters),
     };
@@ -68,6 +68,9 @@ export function buildColdChainNotificationInputs(config: CCNotification): {
     configurationData: JSON.stringify(config),
     status: config.status,
     parameters: config.parameters,
+    recipientIds: config.recipientIds,
+    recipientListIds: config.recipientListIds,
+    sqlRecipientListIds: config.sqlRecipientListIds,
   };
 
   return {

--- a/frontend/packages/system/src/Notifications/Pages/Scheduled/parseConfig.ts
+++ b/frontend/packages/system/src/Notifications/Pages/Scheduled/parseConfig.ts
@@ -19,6 +19,10 @@ export function parseScheduledNotificationConfig(
       id: config.id,
       title: config.title,
       kind: config.kind,
+      parameters: config.parameters,
+      recipientIds: config.recipientIds,
+      recipientListIds: config.recipientListIds,
+      sqlRecipientListIds: config.sqlRecipientListIds,
       ...JSON.parse(config.configurationData),
     };
   } catch (e) {
@@ -65,6 +69,9 @@ export function buildScheduledNotificationInputs(
     configurationData: JSON.stringify(config),
     status: config.status,
     parameters: config.parameters,
+    recipientIds: config.recipientIds,
+    recipientListIds: config.recipientListIds,
+    sqlRecipientListIds: config.sqlRecipientListIds,
   };
   return {
     create: { ...input, kind: config.kind },

--- a/frontend/packages/system/src/Notifications/api/operations.generated.ts
+++ b/frontend/packages/system/src/Notifications/api/operations.generated.ts
@@ -3,7 +3,7 @@ import * as Types from '@notify-frontend/common';
 import { GraphQLClient } from 'graphql-request';
 import * as Dom from 'graphql-request/dist/types.dom';
 import gql from 'graphql-tag';
-export type NotificationConfigRowFragment = { __typename: 'NotificationConfigNode', id: string, title: string, kind: Types.ConfigKind, configurationData: string, status: Types.ConfigStatus, parameters: string };
+export type NotificationConfigRowFragment = { __typename: 'NotificationConfigNode', id: string, title: string, kind: Types.ConfigKind, configurationData: string, status: Types.ConfigStatus, parameters: string, recipientIds: Array<string>, recipientListIds: Array<string>, sqlRecipientListIds: Array<string> };
 
 export type NotificationConfigsQueryVariables = Types.Exact<{
   filter?: Types.InputMaybe<Types.NotificationConfigFilterInput>;
@@ -12,21 +12,21 @@ export type NotificationConfigsQueryVariables = Types.Exact<{
 }>;
 
 
-export type NotificationConfigsQuery = { __typename: 'FullQuery', notificationConfigs: { __typename: 'NotificationConfigConnector', totalCount: number, nodes: Array<{ __typename: 'NotificationConfigNode', id: string, title: string, kind: Types.ConfigKind, configurationData: string, status: Types.ConfigStatus, parameters: string }> } };
+export type NotificationConfigsQuery = { __typename: 'FullQuery', notificationConfigs: { __typename: 'NotificationConfigConnector', totalCount: number, nodes: Array<{ __typename: 'NotificationConfigNode', id: string, title: string, kind: Types.ConfigKind, configurationData: string, status: Types.ConfigStatus, parameters: string, recipientIds: Array<string>, recipientListIds: Array<string>, sqlRecipientListIds: Array<string> }> } };
 
 export type CreateNotificationConfigMutationVariables = Types.Exact<{
   input: Types.CreateNotificationConfigInput;
 }>;
 
 
-export type CreateNotificationConfigMutation = { __typename: 'FullMutation', createNotificationConfig: { __typename: 'NotificationConfigNode', id: string, title: string, kind: Types.ConfigKind, configurationData: string, status: Types.ConfigStatus, parameters: string } };
+export type CreateNotificationConfigMutation = { __typename: 'FullMutation', createNotificationConfig: { __typename: 'NotificationConfigNode', id: string, title: string, kind: Types.ConfigKind, configurationData: string, status: Types.ConfigStatus, parameters: string, recipientIds: Array<string>, recipientListIds: Array<string>, sqlRecipientListIds: Array<string> } };
 
 export type UpdateNotificationConfigMutationVariables = Types.Exact<{
   input: Types.UpdateNotificationConfigInput;
 }>;
 
 
-export type UpdateNotificationConfigMutation = { __typename: 'FullMutation', updateNotificationConfig: { __typename: 'NotificationConfigNode', id: string, title: string, kind: Types.ConfigKind, configurationData: string, status: Types.ConfigStatus, parameters: string } };
+export type UpdateNotificationConfigMutation = { __typename: 'FullMutation', updateNotificationConfig: { __typename: 'NotificationConfigNode', id: string, title: string, kind: Types.ConfigKind, configurationData: string, status: Types.ConfigStatus, parameters: string, recipientIds: Array<string>, recipientListIds: Array<string>, sqlRecipientListIds: Array<string> } };
 
 export type DeleteNotificationConfigMutationVariables = Types.Exact<{
   id: Types.Scalars['String']['input'];
@@ -43,6 +43,9 @@ export const NotificationConfigRowFragmentDoc = gql`
   configurationData
   status
   parameters
+  recipientIds
+  recipientListIds
+  sqlRecipientListIds
 }
     `;
 export const NotificationConfigsDocument = gql`

--- a/frontend/packages/system/src/Notifications/api/operations.graphql
+++ b/frontend/packages/system/src/Notifications/api/operations.graphql
@@ -5,6 +5,9 @@ fragment NotificationConfigRow on NotificationConfigNode {
   configurationData
   status
   parameters
+  recipientIds
+  recipientListIds
+  sqlRecipientListIds
 }
 
 query NotificationConfigs(

--- a/frontend/packages/system/src/Notifications/types.ts
+++ b/frontend/packages/system/src/Notifications/types.ts
@@ -1,21 +1,23 @@
-import { ConfigKind } from '@common/types';
 import { NotificationConfigRowFragment } from './api';
 import { KeyedParams } from '@common/utils';
 
 type BaseConfig = Pick<
   NotificationConfigRowFragment,
-  'id' | 'kind' | 'title' | 'status' | 'parameters'
+  | 'id'
+  | 'kind'
+  | 'title'
+  | 'status'
+  | 'parameters'
+  | 'recipientIds'
+  | 'recipientListIds'
+  | 'sqlRecipientListIds'
 >;
 
 export interface BaseNotificationConfig extends BaseConfig {
-  recipientIds: string[];
-  recipientListIds: string[];
-  sqlRecipientListIds: string[];
   parsedParameters: KeyedParams;
 }
 
 export interface CCNotification extends BaseNotificationConfig {
-  kind: ConfigKind;
   highTemp: boolean;
   lowTemp: boolean;
   confirmOk: boolean;
@@ -26,8 +28,6 @@ export interface CCNotification extends BaseNotificationConfig {
 }
 
 export interface ScheduledNotification extends BaseNotificationConfig {
-  kind: ConfigKind;
-  parameters: string; // JSON for now
   scheduleFrequency: string;
   scheduleStartTime: Date;
   subjectTemplate: string;


### PR DESCRIPTION

Closes #148

# 👩🏻‍💻 What does this PR do?
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

When processing a notification, we need to make sure that shared information (such as recipients) are made available to the backend. Treating these fields separately makes this easier to deal with.


# 🧪 How has/should this change been tested?
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Need to test that these are appropriately managed in both Cold chain and Scheduled notifications

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

Needed for #138
