### PR TITLE
138 scheduled notifications should send to configured recipients

### DIFF
--- a/backend/repository/src/mock/mod.rs
+++ b/backend/repository/src/mock/mod.rs
@@ -12,12 +12,14 @@ mod recipient_lists;
 pub use recipient_lists::*;
 mod recipient_list_members;
 pub use recipient_list_members::*;
+mod sql_recipient_list;
+pub use sql_recipient_list::*;
 
 use crate::{
     NotificationConfigRow, NotificationConfigRowRepository, RecipientListMemberRow,
     RecipientListMemberRowRepository, RecipientListRow, RecipientListRowRepository, RecipientRow,
-    RecipientRowRepository, UserAccountRow, UserAccountRowRepository, UserPermissionRow,
-    UserPermissionRowRepository,
+    RecipientRowRepository, SqlRecipientListRow, SqlRecipientListRowRepository, UserAccountRow,
+    UserAccountRowRepository, UserPermissionRow, UserPermissionRowRepository,
 };
 
 use super::StorageConnection;
@@ -29,6 +31,7 @@ pub struct MockData {
     pub recipients: Vec<RecipientRow>,
     pub recipient_lists: Vec<RecipientListRow>,
     pub recipient_list_members: Vec<RecipientListMemberRow>,
+    pub sql_recipient_lists: Vec<SqlRecipientListRow>,
     pub notification_configs: Vec<NotificationConfigRow>,
 }
 
@@ -39,6 +42,7 @@ pub struct MockDataInserts {
     pub recipients: bool,
     pub recipient_lists: bool,
     pub recipient_list_members: bool,
+    pub sql_recipient_lists: bool,
     pub notification_configs: bool,
 }
 
@@ -50,6 +54,7 @@ impl MockDataInserts {
             recipients: true,
             recipient_lists: true,
             recipient_list_members: true,
+            sql_recipient_lists: true,
             notification_configs: true,
         }
     }
@@ -83,6 +88,11 @@ impl MockDataInserts {
         self.recipients = true;
         self.recipient_lists = true;
         self.recipient_list_members = true;
+        self
+    }
+
+    pub fn sql_recipient_lists(mut self) -> Self {
+        self.sql_recipient_lists = true;
         self
     }
 
@@ -132,6 +142,7 @@ fn all_mock_data() -> MockDataCollection {
             recipients: mock_recipients(),
             recipient_lists: mock_recipient_lists(),
             recipient_list_members: mock_recipient_list_members(),
+            sql_recipient_lists: mock_sql_recipient_lists(),
             notification_configs: mock_notification_configs(),
         },
     );
@@ -181,6 +192,12 @@ pub async fn insert_mock_data(
                 repo.insert_one(row).unwrap();
             }
         }
+        if inserts.sql_recipient_lists {
+            let repo = SqlRecipientListRowRepository::new(connection);
+            for row in &mock_data.sql_recipient_lists {
+                repo.insert_one(row).unwrap();
+            }
+        }
         if inserts.notification_configs {
             let repo = NotificationConfigRowRepository::new(connection);
             for row in &mock_data.notification_configs {
@@ -200,6 +217,7 @@ impl MockData {
             mut recipients,
             mut recipient_lists,
             mut recipient_list_members,
+            mut sql_recipient_lists,
             mut notification_configs,
         } = other;
 
@@ -209,6 +227,7 @@ impl MockData {
         self.recipient_lists.append(&mut recipient_lists);
         self.recipient_list_members
             .append(&mut recipient_list_members);
+        self.sql_recipient_lists.append(&mut sql_recipient_lists);
         self.notification_configs.append(&mut notification_configs);
 
         self

--- a/backend/repository/src/mock/sql_recipient_list.rs
+++ b/backend/repository/src/mock/sql_recipient_list.rs
@@ -1,0 +1,34 @@
+use crate::SqlRecipientListRow;
+
+pub fn mock_sql_recipient_lists() -> Vec<SqlRecipientListRow> {
+    vec![
+        mock_sql_recipient_list_with_param(),
+        mock_sql_recipient_list_with_no_param(),
+    ]
+}
+
+pub fn mock_sql_recipient_list_with_param() -> SqlRecipientListRow {
+    let sql_query = r#"SELECT '{{ email_address }}' as id, '{{ email_address }}' as name, 
+                        'EMAIL' as notification_type, '{{ email_address }}' as to_address"#;
+    SqlRecipientListRow {
+        id: String::from("id_sql_recipient_list_with_param"),
+        name: String::from("sql_recipient_list_with_param"),
+        description: String::from("This is SQL Recipient List with an email address parameter, it should return a single row with to_address set to what ever you pass as the email_address parameter"),
+        query: sql_query.to_string(),
+        required_parameters: "[\"email_address\"]".to_string(),
+        ..Default::default()
+    }
+}
+
+pub fn mock_sql_recipient_list_with_no_param() -> SqlRecipientListRow {
+    let sql_query = r#"SELECT 'id_no_param' as id, 'name_no_param' as name, 
+                        'EMAIL' as notification_type, 'name_no_param@example.com' as to_address"#;
+    SqlRecipientListRow {
+        id: String::from("id_sql_recipient_list_no_param"),
+        name: String::from("sql_recipient_list_no_param"),
+        description: String::from("This is SQL Recipient List with no parameters, it should return a single row name_no_param@example.com as to_address"),
+        query: sql_query.to_string(),
+        required_parameters: "[]".to_string(),
+        ..Default::default()
+    }
+}

--- a/backend/scheduled/src/parse.rs
+++ b/backend/scheduled/src/parse.rs
@@ -6,10 +6,10 @@ use crate::NotificationError;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ScheduledNotificationPluginConfig {
-    body_template: String,
-    subject_template: String,
-    schedule_frequency: String,
-    schedule_start_time: DateTime<Utc>,
+    pub body_template: String,
+    pub subject_template: String,
+    pub schedule_frequency: String,
+    pub schedule_start_time: DateTime<Utc>,
 }
 
 impl ScheduledNotificationPluginConfig {

--- a/backend/scheduled/src/process.rs
+++ b/backend/scheduled/src/process.rs
@@ -1,8 +1,8 @@
 use chrono::{DateTime, NaiveDateTime, Utc};
-use repository::{NotificationConfigKind, NotificationConfigRowRepository, NotificationType};
+use repository::{NotificationConfigKind, NotificationConfigRowRepository};
 use service::{
-    notification::enqueue::{create_notification_events, NotificationContext, NotificationTarget},
-    notification_config::query::NotificationConfig,
+    notification::enqueue::{create_notification_events, NotificationContext},
+    notification_config::{query::NotificationConfig, recipients::get_notification_targets},
     service_provider::ServiceContext,
 };
 
@@ -56,6 +56,7 @@ pub fn process_scheduled_notifications(
     Ok(notifications_processed)
 }
 
+#[derive(Debug, PartialEq)]
 enum ProcessingResult {
     Success,
     Skipped(String),
@@ -109,13 +110,11 @@ fn try_process_scheduled_notifications(
         NotificationError::InternalError(format!("Failed to parse template data: {:?}", e))
     })?;
 
-    // TODO: get the real recipients - https://github.com/openmsupply/notify/issues/138
     // Get the recipients
-    let recipient1 = NotificationTarget {
-        name: "test".to_string(),
-        to_address: "test@example.com".to_string(),
-        notification_type: NotificationType::Email,
-    };
+    let notification_targets =
+        get_notification_targets(ctx, &scheduled_notification).map_err(|e| {
+            NotificationError::InternalError(format!("Failed to get notification targets: {:?}", e))
+        })?;
 
     // For now just send a test notification!
     // TODO: Send the real notification template https://github.com/openmsupply/notify/issues/136
@@ -124,7 +123,7 @@ fn try_process_scheduled_notifications(
         title_template_name: Some("test_message/email_subject.html".to_string()),
         body_template_name: "test_message/email.html".to_string(),
         template_data: template_data,
-        recipients: vec![recipient1],
+        recipients: notification_targets,
     };
 
     create_notification_events(ctx, Some(scheduled_notification.id), notification)
@@ -138,10 +137,14 @@ mod test {
 
     use std::sync::Arc;
 
+    use chrono::Days;
+    use repository::mock::{mock_recipient_a, mock_recipient_list_with_recipient_members_a_and_b};
+    use repository::NotificationEventRowRepository;
     use repository::{mock::MockDataInserts, test_db::setup_all};
     use service::test_utils::get_test_settings;
 
     use service::service_provider::ServiceProvider;
+    use service::test_utils::telegram_test::send_test_notifications;
 
     use super::*;
 
@@ -170,4 +173,117 @@ mod test {
         // Test that it skips a scheduled notification with a due date in the future
         // Test that it runs a scheduled notification with a due date in the past
     }
+
+    // Test that we get a notification when we have a recipient list configured
+    #[tokio::test]
+    async fn test_try_process_scheduled_notifications_with_recipient_list() {
+        let (_, _, connection_manager, _) = setup_all(
+            "test_try_process_scheduled_notifications_with_recipient_list",
+            MockDataInserts::none()
+                .recipients()
+                .recipient_lists()
+                .recipient_list_members(),
+        )
+        .await;
+
+        let service_provider = Arc::new(ServiceProvider::new(
+            connection_manager,
+            get_test_settings(""),
+        ));
+
+        let service_context = ServiceContext::new(service_provider).unwrap();
+
+        // Daily Scheduled Notification that started this time yesterday
+        let sch_config = ScheduledNotificationPluginConfig {
+            body_template: "TestTemplate".to_string(),
+            subject_template: "TestSubject".to_string(),
+            schedule_frequency: "daily".to_string(),
+            schedule_start_time: Utc::now().checked_sub_days(Days::new(1)).unwrap(),
+        };
+
+        // Create a notification config with a recipient list
+        let notification_config = NotificationConfig {
+            id: "notification_config_1".to_string(),
+            kind: NotificationConfigKind::Scheduled,
+            recipient_ids: vec![],
+            recipient_list_ids: vec![mock_recipient_list_with_recipient_members_a_and_b().id],
+            sql_recipient_list_ids: vec![],
+            next_due_datetime: Some(chrono::Utc::now().naive_utc()),
+            configuration_data: serde_json::to_string(&sch_config).unwrap(),
+            ..Default::default()
+        };
+
+        // Try to process the notification (Should be due now)
+        let result = try_process_scheduled_notifications(
+            &service_context,
+            notification_config,
+            chrono::Utc::now().naive_utc(),
+        )
+        .unwrap();
+
+        assert_eq!(result, ProcessingResult::Success);
+
+        // Query the database to check that we have a notification events for each recipient
+        let repo = NotificationEventRowRepository::new(&service_context.connection);
+        let notification_events = repo.un_sent().unwrap();
+
+        assert_eq!(notification_events.len(), 2);
+
+        send_test_notifications(&service_context).await;
+    }
+
+    // Test that we get a notification when we have a recipient configured
+    #[tokio::test]
+    async fn test_try_process_scheduled_notifications_with_recipient() {
+        let (_, _, connection_manager, _) = setup_all(
+            "test_try_process_scheduled_notifications_with_recipient",
+            MockDataInserts::none().recipients(),
+        )
+        .await;
+
+        let service_provider = Arc::new(ServiceProvider::new(
+            connection_manager,
+            get_test_settings(""),
+        ));
+
+        let service_context = ServiceContext::new(service_provider).unwrap();
+
+        // Daily Scheduled Notification that started this time yesterday
+        let sch_config = ScheduledNotificationPluginConfig {
+            body_template: "TestTemplate".to_string(),
+            subject_template: "TestSubject".to_string(),
+            schedule_frequency: "daily".to_string(),
+            schedule_start_time: Utc::now().checked_sub_days(Days::new(1)).unwrap(),
+        };
+
+        // Create a notification config with a recipient list
+        let notification_config = NotificationConfig {
+            id: "notification_config_1".to_string(),
+            kind: NotificationConfigKind::Scheduled,
+            recipient_ids: vec![mock_recipient_a().id],
+            recipient_list_ids: vec![],
+            sql_recipient_list_ids: vec![],
+            next_due_datetime: Some(chrono::Utc::now().naive_utc()),
+            configuration_data: serde_json::to_string(&sch_config).unwrap(),
+            ..Default::default()
+        };
+
+        // Try to process the notification (Should be due now)
+        let result = try_process_scheduled_notifications(
+            &service_context,
+            notification_config,
+            chrono::Utc::now().naive_utc(),
+        )
+        .unwrap();
+
+        assert_eq!(result, ProcessingResult::Success);
+
+        // Query the database to check that we have a notification events for the 1 configured recipient
+        let repo = NotificationEventRowRepository::new(&service_context.connection);
+        let notification_events = repo.un_sent().unwrap();
+
+        assert_eq!(notification_events.len(), 1);
+    }
+
+    // Test that we get a notification when we have a sql recipient list configured
 }

--- a/backend/service/src/notification/enqueue.rs
+++ b/backend/service/src/notification/enqueue.rs
@@ -12,7 +12,7 @@ use super::NotificationServiceError;
 
 // This struct is intended to be able to be created by a plugin from a datasource, and defines what a template can expect from a recipient
 // Often it will be derived RecipientRow which is why we implement From<RecipientRow> for NotificationRecipient
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct NotificationTarget {
     pub name: String,
     pub to_address: String,

--- a/backend/service/src/notification_config/mod.rs
+++ b/backend/service/src/notification_config/mod.rs
@@ -20,6 +20,7 @@ mod tests;
 pub mod create;
 pub mod delete;
 pub mod query;
+pub mod recipients;
 pub mod update;
 pub mod validate;
 

--- a/backend/service/src/notification_config/query.rs
+++ b/backend/service/src/notification_config/query.rs
@@ -14,7 +14,7 @@ use crate::{
 pub const MAX_LIMIT: u32 = 1000;
 pub const MIN_LIMIT: u32 = 1;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct NotificationConfig {
     pub id: String,
     pub title: String,

--- a/backend/service/src/notification_config/recipients.rs
+++ b/backend/service/src/notification_config/recipients.rs
@@ -41,8 +41,10 @@ pub fn get_notification_targets(
         .query_by_filter(RecipientFilter::new().id(EqualFilter::equal_any(all_recipient_ids)))?;
 
     // Convert the recipients into NotificationTargets
-    let recipients: Vec<NotificationTarget> =
-        recipients.into_iter().map(|row| row.into()).collect();
+    let recipients: Vec<NotificationTarget> = recipients
+        .into_iter()
+        .map(NotificationTarget::from)
+        .collect();
     notification_targets.extend(recipients);
 
     // loop through all the sql recipient lists

--- a/backend/service/src/notification_config/recipients.rs
+++ b/backend/service/src/notification_config/recipients.rs
@@ -1,0 +1,157 @@
+use repository::{
+    EqualFilter, RecipientFilter, RecipientListMemberFilter, RecipientListMemberRepository,
+    RecipientRepository,
+};
+
+use crate::{notification::enqueue::NotificationTarget, service_provider::ServiceContext};
+
+use super::{query::NotificationConfig, ModifyNotificationConfigError};
+
+pub fn get_notification_targets(
+    ctx: &ServiceContext,
+    notification_config: &NotificationConfig,
+) -> Result<Vec<NotificationTarget>, ModifyNotificationConfigError> {
+    let mut notification_targets: Vec<NotificationTarget> = Vec::new();
+
+    // // Get the recipients based on recipient list ids
+    let recipient_list_member_repository = RecipientListMemberRepository::new(&ctx.connection);
+
+    // get the recipient list members
+    let recipient_list_members = recipient_list_member_repository.query_by_filter(
+        RecipientListMemberFilter::new().recipient_list_id(EqualFilter::equal_any(
+            notification_config.recipient_list_ids.clone(),
+        )),
+    )?;
+    let mut all_recipient_ids: Vec<String> = recipient_list_members
+        .into_iter()
+        .map(|row| row.recipient_id)
+        .collect();
+
+    // Add the configured recipient ids to the ones from any lists
+    all_recipient_ids.extend(notification_config.recipient_ids.clone());
+
+    let recipient_repository = RecipientRepository::new(&ctx.connection);
+    // Get the recipients by recipient ids
+    let recipients = recipient_repository
+        .query_by_filter(RecipientFilter::new().id(EqualFilter::equal_any(all_recipient_ids)))?;
+
+    // Convert the recipients into NotificationTargets
+    let recipients: Vec<NotificationTarget> =
+        recipients.into_iter().map(|row| row.into()).collect();
+    notification_targets.extend(recipients);
+
+    // // TODO: Get the sql recipient list ids
+    // let sql_recipient_list_ids = match &notification_config.sql_recipient_list_ids {
+    //     Some(ids) => ids,
+    //     None => {
+    //         [];
+    //     }
+    // };
+    Ok(notification_targets)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use repository::{
+        mock::{
+            mock_recipient_a, mock_recipient_b, mock_recipient_list_with_recipient_members_a_and_b,
+            MockDataInserts,
+        },
+        test_db::setup_all,
+        NotificationConfigStatus,
+    };
+    use util::uuid::uuid;
+
+    use crate::{service_provider::ServiceProvider, test_utils::get_test_settings};
+
+    use super::*;
+
+    #[actix_rt::test]
+    async fn test_get_notification_targets() {
+        let (_, _, connection_manager, _) = setup_all(
+            "test_get_notification_targets",
+            MockDataInserts::none()
+                .recipients()
+                .recipient_lists()
+                .recipient_list_members(),
+        )
+        .await;
+        let service_provider = Arc::new(ServiceProvider::new(
+            connection_manager,
+            get_test_settings(""),
+        ));
+        let context = ServiceContext::as_server_admin(service_provider).unwrap();
+
+        // We'll use the mock recipients and recipient lists
+
+        let recipient1 = mock_recipient_a();
+        let recipient2 = mock_recipient_b();
+        let recipient_list1 = mock_recipient_list_with_recipient_members_a_and_b();
+
+        // 1. Check we get the 2 recipients with both recipient list and recipient ids
+
+        // Create a notification config with recipient list and individual recipient ids
+        let notification_config = NotificationConfig {
+            id: uuid(),
+            recipient_ids: vec![recipient1.id.clone(), recipient2.id.clone()],
+            recipient_list_ids: vec![recipient_list1.id.clone()],
+            sql_recipient_list_ids: vec![],
+            status: NotificationConfigStatus::Enabled,
+            ..Default::default()
+        };
+
+        // Call the function being tested
+        let notification_targets =
+            get_notification_targets(&context, &notification_config).unwrap();
+
+        // Check that the correct recipients were returned
+        assert_eq!(notification_targets.len(), 2); // Recipient A & B
+
+        assert!(notification_targets.contains(&NotificationTarget::from(recipient1.clone())));
+        assert!(notification_targets.contains(&NotificationTarget::from(recipient2.clone())));
+
+        // 2. Check we get the result with just the recipient list
+        let notification_config = NotificationConfig {
+            id: uuid(),
+            recipient_ids: vec![],
+            recipient_list_ids: vec![recipient_list1.id.clone()],
+            sql_recipient_list_ids: vec![],
+            status: NotificationConfigStatus::Enabled,
+            ..Default::default()
+        };
+
+        // Call the function being tested
+        let notification_targets =
+            get_notification_targets(&context, &notification_config).unwrap();
+
+        // Check that the correct recipients were returned
+        assert_eq!(notification_targets.len(), 2); // Recipient A & B
+
+        assert!(notification_targets.contains(&NotificationTarget::from(recipient1.clone())));
+        assert!(notification_targets.contains(&NotificationTarget::from(recipient2.clone())));
+
+        // 3. Check we get the result with just the recipients
+        let notification_config = NotificationConfig {
+            id: uuid(),
+            recipient_ids: vec![recipient1.id.clone(), recipient2.id.clone()],
+            recipient_list_ids: vec![],
+            sql_recipient_list_ids: vec![],
+            status: NotificationConfigStatus::Enabled,
+            ..Default::default()
+        };
+
+        // Call the function being tested
+        let notification_targets =
+            get_notification_targets(&context, &notification_config).unwrap();
+
+        // Check that the correct recipients were returned
+        assert_eq!(notification_targets.len(), 2); // Recipient A & B
+
+        assert!(notification_targets.contains(&NotificationTarget::from(recipient1.clone())));
+        assert!(notification_targets.contains(&NotificationTarget::from(recipient2.clone())));
+
+        // TODO: Test SQL Recipients
+    }
+}

--- a/backend/service/src/notification_config/recipients.rs
+++ b/backend/service/src/notification_config/recipients.rs
@@ -66,7 +66,7 @@ pub fn get_notification_targets(
                         notification_type: repository::NotificationType::from_str(
                             &row.notification_type,
                         )
-                        .unwrap_or_default(),
+                        .unwrap_or_default(), // Default to an email address if the notification type is invalid, probably won't work but doesn't hurt to try something
                     })
                     .collect();
                 notification_targets.extend(sql_recipients);


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Closes #138 & #73 

# 👩🏻‍💻 What does this PR do?
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

This PR updates the `process_scheduled_notifications` function to send to the configured recipients.
This uses the newly create `get_notification_targets` function. 
This returns `NotificationTargets` based on any configured `recipients`, `recipients` or `sql_recipient_lists` configured

# 🧪 How has/should this change been tested?
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->
Configure a scheduled notification with different combinations for recipients, lists, and sql lists.
Check the right address & channels receive the test messages.


## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->
