### PR TITLE
Render templates

### DIFF
--- a/backend/coldchain/src/lib.rs
+++ b/backend/coldchain/src/lib.rs
@@ -3,7 +3,9 @@ use serde::Serialize;
 use service::{
     notification::{
         self,
-        enqueue::{create_notification_events, NotificationContext, NotificationTarget},
+        enqueue::{
+            create_notification_events, NotificationContext, NotificationTarget, TemplateDefinition,
+        },
     },
     service_provider::ServiceContext,
 };
@@ -44,8 +46,12 @@ pub async fn send_high_temperature_alert_telegram(
     recipients: Vec<NotificationTarget>,
 ) -> Result<(), notification::NotificationServiceError> {
     let notification = NotificationContext {
-        title_template_name: Some("coldchain/telegram/temperature_title.html".to_string()),
-        body_template_name: "coldchain/telegram/temperature.html".to_string(),
+        title_template: Some(TemplateDefinition::TemplateName(
+            "coldchain/telegram/temperature_title.html".to_string(),
+        )),
+        body_template: TemplateDefinition::TemplateName(
+            "coldchain/telegram/temperature.html".to_string(),
+        ),
         recipients,
         template_data: serde_json::to_value(alert).map_err(|e| {
             notification::NotificationServiceError::GenericError(format!(

--- a/backend/scheduled/src/process.rs
+++ b/backend/scheduled/src/process.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, NaiveDateTime, Utc};
 use repository::{NotificationConfigKind, NotificationConfigRowRepository};
 use service::{
-    notification::enqueue::{create_notification_events, NotificationContext},
+    notification::enqueue::{create_notification_events, NotificationContext, TemplateDefinition},
     notification_config::{query::NotificationConfig, recipients::get_notification_targets},
     service_provider::ServiceContext,
 };
@@ -116,12 +116,10 @@ fn try_process_scheduled_notifications(
             NotificationError::InternalError(format!("Failed to get notification targets: {:?}", e))
         })?;
 
-    // For now just send a test notification!
-    // TODO: Send the real notification template https://github.com/openmsupply/notify/issues/136
     // Send the notification
     let notification = NotificationContext {
-        title_template_name: Some("test_message/email_subject.html".to_string()),
-        body_template_name: "test_message/email.html".to_string(),
+        title_template: Some(TemplateDefinition::Template(config.subject_template)),
+        body_template: TemplateDefinition::Template(config.body_template),
         template_data: template_data,
         recipients: notification_targets,
     };

--- a/backend/service/src/notification/enqueue.rs
+++ b/backend/service/src/notification/enqueue.rs
@@ -4,6 +4,7 @@ use repository::{
     NotificationType, RecipientRow,
 };
 use serde::Serialize;
+use tera::{Context, Tera};
 use util::uuid::uuid;
 
 use crate::service_provider::ServiceContext;
@@ -30,9 +31,15 @@ impl From<RecipientRow> for NotificationTarget {
 }
 
 #[derive(Debug)]
+pub enum TemplateDefinition {
+    TemplateName(String),
+    Template(String),
+}
+
+#[derive(Debug)]
 pub struct NotificationContext {
-    pub title_template_name: Option<String>,
-    pub body_template_name: String,
+    pub title_template: Option<TemplateDefinition>,
+    pub body_template: TemplateDefinition,
     pub recipients: Vec<NotificationTarget>,
     pub template_data: serde_json::Value,
 }
@@ -46,12 +53,57 @@ pub fn create_notification_events(
 
     // TODO: Should this function use a notification config to get the template, users, etc?
 
+    // Create a tera instance for this notification
+    let mut tera = Tera::default();
+    // Add any configured templates to out new tera instance
+    tera.extend(ctx.service_provider.notification_service.tera())
+        .map_err(|e| {
+            NotificationServiceError::GenericError(format!(
+                "Failed to extend tera instance with notification service templates: {:?}",
+                e
+            ))
+        })?;
+
+    let title_template_name = match notification.title_template {
+        Some(TemplateDefinition::TemplateName(title_template_name)) => title_template_name,
+        Some(TemplateDefinition::Template(title_template)) => {
+            // Add the title template to the tera instance
+            tera.add_raw_template("title_template", &title_template)
+                .map_err(|e| {
+                    NotificationServiceError::GenericError(format!(
+                        "Failed to add title template to tera instance: {:?}",
+                        e
+                    ))
+                })?;
+            "title_template".to_string()
+        }
+        None => "default/title.html".to_string(),
+    };
+
+    let body_template_name = match notification.body_template {
+        TemplateDefinition::TemplateName(body_template_name) => body_template_name,
+        TemplateDefinition::Template(body_template) => {
+            // Add the body template to the tera instance
+            tera.add_raw_template("body_template", &body_template)
+                .map_err(|e| {
+                    NotificationServiceError::GenericError(format!(
+                        "Failed to add body template to tera instance: {:?}",
+                        e
+                    ))
+                })?;
+            "body_template".to_string()
+        }
+    };
+
+    let mut tera_context = Context::from_serialize(notification.template_data.clone())
+        .map_err(|e| NotificationServiceError::GenericError(format!("{:?}", e)))?;
+
     // Loop through recipients and create a notification for each
     for recipient in notification.recipients {
         let notification_type = recipient.notification_type.clone();
 
-        let mut template_context: serde_json::Value = notification.template_data.clone();
-        template_context["recipient"] = serde_json::to_value(recipient.clone()).unwrap_or_default();
+        // Replace the recipient data in the template context
+        tera_context.insert("recipient", &recipient);
 
         let base_row = NotificationEventRow {
             id: uuid(),
@@ -67,53 +119,32 @@ pub fn create_notification_events(
             ..Default::default()
         };
 
-        let base_row_with_title = match notification.title_template_name.clone() {
-            Some(title_template_name) => {
-                let title = ctx
-                    .service_provider
-                    .notification_service
-                    .render(&title_template_name, &template_context);
-
-                match title {
-                    Ok(title) => NotificationEventRow {
-                        title: Some(title),
-                        ..base_row
-                    },
-                    Err(e) => {
-                        log::error!("Failed to render notification title template: {:?}", e);
-                        NotificationEventRow {
-                            status: NotificationEventStatus::Errored,
-                            error_message: Some(format!("{:?}", e)),
-                            ..base_row
-                        }
-                    }
+        let base_row_with_title = match tera.render(&title_template_name, &tera_context) {
+            Ok(title) => NotificationEventRow {
+                title: Some(title),
+                ..base_row
+            },
+            Err(e) => {
+                log::error!("Failed to render notification title template: {:?}", e);
+                NotificationEventRow {
+                    status: NotificationEventStatus::Errored,
+                    error_message: Some(format!("{:?}", e)),
+                    ..base_row
                 }
             }
-            None => base_row,
         };
 
-        let notification_queue_row = match base_row_with_title.status {
-            NotificationEventStatus::Errored => base_row_with_title,
-            _ => {
-                let message = ctx
-                    .service_provider
-                    .notification_service
-                    .render(&notification.body_template_name.clone(), &template_context);
-
-                match message {
-                    Ok(message) => NotificationEventRow {
-                        status: NotificationEventStatus::Queued,
-                        message,
-                        ..base_row_with_title
-                    },
-                    Err(e) => {
-                        log::error!("Failed to render notification template: {:?}", e);
-                        NotificationEventRow {
-                            status: NotificationEventStatus::Failed, // Permanent Error TODO: check if this is permanent or temporary failure, retries, and exponential backoff etc
-                            error_message: Some(format!("{:?}", e)),
-                            ..base_row_with_title
-                        }
-                    }
+        let notification_queue_row = match tera.render(&body_template_name, &tera_context) {
+            Ok(body) => NotificationEventRow {
+                message: body,
+                ..base_row_with_title
+            },
+            Err(e) => {
+                log::error!("Failed to render notification title template: {:?}", e);
+                NotificationEventRow {
+                    status: NotificationEventStatus::Errored,
+                    error_message: Some(format!("{:?}", e)),
+                    ..base_row_with_title
                 }
             }
         };
@@ -137,7 +168,7 @@ mod test {
 
     use crate::{
         notification::enqueue::{
-            create_notification_events, NotificationContext, NotificationTarget,
+            create_notification_events, NotificationContext, NotificationTarget, TemplateDefinition,
         },
         service_provider::{ServiceContext, ServiceProvider},
         test_utils::get_test_settings,
@@ -162,8 +193,12 @@ mod test {
             &context,
             None,
             NotificationContext {
-                title_template_name: Some("test_message/email_subject.html".to_string()),
-                body_template_name: "test_message/email.html".to_string(),
+                title_template: Some(TemplateDefinition::TemplateName(
+                    "test_message/email_subject.html".to_string(),
+                )),
+                body_template: TemplateDefinition::TemplateName(
+                    "test_message/email.html".to_string(),
+                ),
                 recipients: vec![NotificationTarget {
                     name: "test".to_string(),
                     to_address: "test@example.com".to_string(),
@@ -206,8 +241,10 @@ mod test {
             &context,
             None,
             NotificationContext {
-                title_template_name: None,
-                body_template_name: "test_message/telegram.html".to_string(),
+                title_template: None,
+                body_template: TemplateDefinition::TemplateName(
+                    "test_message/telegram.html".to_string(),
+                ),
                 recipients: vec![NotificationTarget {
                     name: "telegram".to_string(),
                     to_address: "-12345".to_string(),

--- a/backend/service/src/notification/mod.rs
+++ b/backend/service/src/notification/mod.rs
@@ -27,6 +27,8 @@ pub trait NotificationServiceTrait: Send + Sync {
 
     fn render_no_params(&self, template_name: &str) -> Result<String, NotificationServiceError>;
 
+    fn tera(&self) -> &Tera;
+
     async fn send_queued_notifications(
         &self,
         ctx: &ServiceContext,
@@ -92,6 +94,9 @@ impl NotificationServiceTrait for NotificationService {
             template_name,
             json!({}),
         )?)
+    }
+    fn tera(&self) -> &Tera {
+        &self.tera
     }
 
     async fn send_queued_notifications(

--- a/backend/templates/default/body.html
+++ b/backend/templates/default/body.html
@@ -1,0 +1,1 @@
+Notification: {{ notification }}

--- a/backend/templates/default/title.html
+++ b/backend/templates/default/title.html
@@ -1,0 +1,1 @@
+Notification

--- a/frontend/packages/common/src/intl/locales/en/host.json
+++ b/frontend/packages/common/src/intl/locales/en/host.json
@@ -47,5 +47,6 @@
   "saving": "Saving...",
   "set-up-account": "Set up your account",
   "username-reset.explanation": "Enter your new log in username",
-  "users": "Users"
+  "users": "Users",
+  "queries": "Queries"
 }


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Closes #136 

# 👩🏻‍💻 What does this PR do?
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

This PR adds templating functionality to Scheduled Notifications.

With this PR notifiy should now send the notification of the configured template rather than a test notification.

It adds a mechanism to access the shared tera instance in the service provider (and therefore provides a mechanism to extend it)
Sending notifications can now be created using a tera template loaded from disk, or from one defined in the scheduled task.

# 🧪 How has/should this change been tested?
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

I'd recommend testing it using mailhog and/or telegram (if you have a bot setup)
It's helpful to save the notification with a run time 1 minute from now, so there's time for it to be processed after you save it.

![image](https://github.com/openmsupply/notify/assets/8287373/1479c127-cef4-495a-a424-36d6f7371009)


Here's an example notification in email:
![image](https://github.com/openmsupply/notify/assets/8287373/f70527d2-e029-414d-a9a5-01fdf0a8fd3a)

and in telegram

![image](https://github.com/openmsupply/notify/assets/8287373/66f252ad-3d22-4c5d-9ea7-e595f64724e9)

![image](https://github.com/openmsupply/notify/assets/8287373/75945a07-df96-457f-8b7a-ec989495a06b)


At this stage you can use the recipient name as a parameter, you can reference it in a template like this...
{{ recipient.name }} (id & to_address are also available)

I'd recommend trying out different broken configurations to see what happens.

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

> Right now there's an issue with telegram alerts if you use unsupport HTML tags `<p></p>` for example!
- [ ] https://github.com/openmsupply/notify/issues/118
