### PR TITLE
Add a build-windows command to yarn for jenkins to use

### DIFF
--- a/build_windows.bat
+++ b/build_windows.bat
@@ -1,0 +1,14 @@
+IF NOT EXIST version.txt (
+    ECHO ##### No version.txt found, defaulting to package version #####
+    node -p "require('./frontend/package.json').version" > version.txt
+)
+
+ECHO ##### Prepare notify frontend #####
+set /p APP_BUILD_VERSION=<version.txt
+echo %APP_BUILD_VERSION%
+cd "frontend" && yarn install --force --frozen-lockfile && yarn build-windows
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+ECHO ##### Building notify backend #####
+cd ../backend && cargo build --release && cargo build --release --bin notify_service
+if %errorlevel% neq 0 exit /b %errorlevel%

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "lerna run --scope @notify-frontend/* --parallel start",
     "build": "lerna run --scope @notify-frontend/* build",
+    "build-windows": "lerna run --scope @notify-frontend/* build-windows",
     "build-stats": "lerna run --scope @notify-frontend/* build-stats",
     "serve": "lerna run --scope @notify-frontend/* --parallel serve",
     "clean": "lerna run --scope @notify-frontend/* --parallel clean",

--- a/frontend/packages/host/package.json
+++ b/frontend/packages/host/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "start": "webpack-cli serve",
     "build": "webpack --env production --env APP_BUILD_VERSION=$APP_BUILD_VERSION",
+    "build-windows": "webpack --env production --env APP_BUILD_VERSION=%APP_BUILD_VERSION%",
     "build-stats": "webpack --env stats --env production",
     "serve": "serve dist -p 3007",
     "tsc": "tsc"


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Closes #178

# 👩🏻‍💻 What does this PR do?
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Passes the version number from jenkins build for windows into the webpack process so it can be shown in the UI.

# 🧪 How has/should this change been tested?
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Tested in Jenkins.

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

I tried various things, and tired to read about how to use [cross-env](https://www.npmjs.com/package/cross-env) but after wasting too much time went with the different build target approach.
Happy for someone else to make it more consistent!

