### PR TITLE
183 cold chain alert date time should be shown in server time

### DIFF
--- a/backend/coldchain/src/process.rs
+++ b/backend/coldchain/src/process.rs
@@ -1,4 +1,4 @@
-use chrono::NaiveDateTime;
+use chrono::{Local, NaiveDateTime};
 use repository::{
     NotificationConfigKind, NotificationConfigRowRepository, NotificationConfigStatus,
 };
@@ -252,7 +252,7 @@ fn try_process_coldchain_notifications(
                     location_name: sensor_row.location_name.clone(),
                     sensor_id: sensor_id.clone(),
                     sensor_name: sensor_row.sensor_name.clone(),
-                    datetime: now,
+                    datetime: Local::now().naive_local(),
                     temperature: current_temp,
                     alert_type: "High".to_string(),
                 }),


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Closes #183

# 👩🏻‍💻 What does this PR do?
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

What it says on the box! Server local time is passed to the alert.
![image](https://github.com/openmsupply/notify/assets/8287373/20d0c25f-5dfa-4314-9168-ae58f13a1a6e)


# 🧪 How has/should this change been tested?
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Only tested locally with my timezone so far.

To test, create a Cold Chain Alert and se what time is displayed

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

Do we need to do more here? Maybe display the actual timezone?

We could allow the user to specify a timezone for alerts?
Pass both UTC and Local time to the template incase people want to do something custom?
