### PR TITLE
137 schedule notifications should load data from sql queries to render in the template

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3167,6 +3167,7 @@ dependencies = [
  "serde_json",
  "service",
  "tokio",
+ "util",
 ]
 
 [[package]]

--- a/backend/repository/src/mock/mod.rs
+++ b/backend/repository/src/mock/mod.rs
@@ -14,12 +14,15 @@ mod recipient_list_members;
 pub use recipient_list_members::*;
 mod sql_recipient_list;
 pub use sql_recipient_list::*;
+mod notification_query;
+pub use notification_query::*;
 
 use crate::{
-    NotificationConfigRow, NotificationConfigRowRepository, RecipientListMemberRow,
-    RecipientListMemberRowRepository, RecipientListRow, RecipientListRowRepository, RecipientRow,
-    RecipientRowRepository, SqlRecipientListRow, SqlRecipientListRowRepository, UserAccountRow,
-    UserAccountRowRepository, UserPermissionRow, UserPermissionRowRepository,
+    NotificationConfigRow, NotificationConfigRowRepository, NotificationQueryRow,
+    NotificationQueryRowRepository, RecipientListMemberRow, RecipientListMemberRowRepository,
+    RecipientListRow, RecipientListRowRepository, RecipientRow, RecipientRowRepository,
+    SqlRecipientListRow, SqlRecipientListRowRepository, UserAccountRow, UserAccountRowRepository,
+    UserPermissionRow, UserPermissionRowRepository,
 };
 
 use super::StorageConnection;
@@ -33,6 +36,7 @@ pub struct MockData {
     pub recipient_list_members: Vec<RecipientListMemberRow>,
     pub sql_recipient_lists: Vec<SqlRecipientListRow>,
     pub notification_configs: Vec<NotificationConfigRow>,
+    pub notification_queries: Vec<NotificationQueryRow>,
 }
 
 #[derive(Default)]
@@ -44,6 +48,7 @@ pub struct MockDataInserts {
     pub recipient_list_members: bool,
     pub sql_recipient_lists: bool,
     pub notification_configs: bool,
+    pub notification_queries: bool,
 }
 
 impl MockDataInserts {
@@ -56,6 +61,7 @@ impl MockDataInserts {
             recipient_list_members: true,
             sql_recipient_lists: true,
             notification_configs: true,
+            notification_queries: true,
         }
     }
 
@@ -98,6 +104,11 @@ impl MockDataInserts {
 
     pub fn notification_configs(mut self) -> Self {
         self.notification_configs = true;
+        self
+    }
+
+    pub fn notification_queries(mut self) -> Self {
+        self.notification_queries = true;
         self
     }
 }
@@ -144,6 +155,7 @@ fn all_mock_data() -> MockDataCollection {
             recipient_list_members: mock_recipient_list_members(),
             sql_recipient_lists: mock_sql_recipient_lists(),
             notification_configs: mock_notification_configs(),
+            notification_queries: mock_notification_queries(),
         },
     );
     data
@@ -204,6 +216,12 @@ pub async fn insert_mock_data(
                 repo.insert_one(row).unwrap();
             }
         }
+        if inserts.notification_queries {
+            let repo = NotificationQueryRowRepository::new(connection);
+            for row in &mock_data.notification_queries {
+                repo.insert_one(row).unwrap();
+            }
+        }
     }
 
     mock_data
@@ -219,6 +237,7 @@ impl MockData {
             mut recipient_list_members,
             mut sql_recipient_lists,
             mut notification_configs,
+            mut notification_queries,
         } = other;
 
         self.user_accounts.append(&mut user_accounts);
@@ -229,6 +248,7 @@ impl MockData {
             .append(&mut recipient_list_members);
         self.sql_recipient_lists.append(&mut sql_recipient_lists);
         self.notification_configs.append(&mut notification_configs);
+        self.notification_queries.append(&mut notification_queries);
 
         self
     }

--- a/backend/repository/src/mock/notification_query.rs
+++ b/backend/repository/src/mock/notification_query.rs
@@ -1,0 +1,37 @@
+use crate::NotificationQueryRow;
+
+pub fn mock_notification_queries() -> Vec<NotificationQueryRow> {
+    vec![
+        mock_notification_query_with_params(),
+        mock_notification_query_with_no_param_2_rows(),
+    ]
+}
+
+pub fn mock_notification_query_with_params() -> NotificationQueryRow {
+    let sql_query = r#"SELECT {{ latest_temperature }} as latest_temperature, {{ sensor_limit }} as sensor_limit, 
+CASE WHEN {{ latest_temperature }} > {{ sensor_limit }} THEN TRUE ELSE FALSE END as is_above_limit
+"#;
+    NotificationQueryRow {
+        id: String::from("id_notification_query_with_params"),
+        name: String::from("notification_query_with_params"),
+        description: String::from("The accepts 2 params, sensor_limit (number) and latest_temperature (number). It returns a single row with temperature (number), sensor_limit (number), and is_above_limit (boolean). is_above_limit is true if latest_temperature is greater than sensor_limit"),
+        query: sql_query.to_string(),
+        required_parameters: "[\"sensor_limit\", \"latest_temperature\"]".to_string(),
+        reference_name: String::from("query1"),
+        ..Default::default()
+    }
+}
+
+pub fn mock_notification_query_with_no_param_2_rows() -> NotificationQueryRow {
+    let sql_query = r#"SELECT 1.25 as latest_temperature, 'sensor1' as sensor_name, -10 as sensor_limit UNION
+SELECT 1.51 as latest_temperature, 'sensor2' as sensor_name, -10 as sensor_limit"#;
+    NotificationQueryRow {
+        id: String::from("id_notification_query_no_param"),
+        name: String::from("notification_query_no_param"),
+        description: String::from("Returns 2 rows, each with temperature (number), sensor_name (string), and sensor_limit (number)"),
+        query: sql_query.to_string(),
+        required_parameters: "[]".to_string(),
+        reference_name: String::from("query2"),
+        ..Default::default()
+    }
+}

--- a/backend/scheduled/Cargo.toml
+++ b/backend/scheduled/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+util = { path = "../util" }
 repository = { path = "../repository" }
 service = { path = "../service" }
 tokio = { version = "1", features = ["macros"] }
@@ -13,3 +14,7 @@ log = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
+
+[features]
+telegram-tests = ["service/telegram-tests"]
+email-tests = ["service/email-tests"]

--- a/backend/scheduled/src/lib.rs
+++ b/backend/scheduled/src/lib.rs
@@ -5,6 +5,7 @@ use service::{
 
 pub mod parse;
 pub mod process;
+pub mod query;
 
 #[derive(Debug)]
 pub enum NotificationError {

--- a/backend/scheduled/src/parse.rs
+++ b/backend/scheduled/src/parse.rs
@@ -3,13 +3,50 @@ use serde::{Deserialize, Serialize};
 
 use crate::NotificationError;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/* Example config:
+{
+    "bodyTemplate": "Some Template",
+    "configurationData": "{}",
+    "id": "fc2a0e0c-440a-4abc-a13b-6b1270a59ff0",
+    "kind": "SCHEDULED",
+    "notificationQueryIds": [
+        "72e5342f-08b7-499b-8a51-339ae142f68a",
+        "98533e08-99bb-4b18-a045-db67e1852d73",
+        "aca03f15-96a1-4f36-bd80-1fd34331a5f1"
+    ],
+    "parameters": "{\"email_address\":\"test@example.com\",\"project\":\"prj1\",\"province\":\"prov1\"}",
+    "parsedParameters": {
+        "email_address": "test@example.com",
+        "project": "prj1",
+        "province": "prov1"
+    },
+    "recipientIds": [],
+    "recipientListIds": [],
+    "requiredParameters": [
+        "email_address",
+        "project",
+        "province"
+    ],
+    "scheduleFrequency": "daily",
+    "scheduleStartTime": "2023-10-11T02:09:31.221Z",
+    "sqlRecipientListIds": [
+        "3f6194ad-1fbb-494b-8ffb-c0f2e1b455d0"
+    ],
+    "status": "DISABLED",
+    "subjectTemplate": "Title Template",
+    "title": "Some Notification Name"
+}
+*/
+
+#[derive(Debug, Clone, Serialize, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ScheduledNotificationPluginConfig {
     pub body_template: String,
     pub subject_template: String,
     pub schedule_frequency: String,
     pub schedule_start_time: DateTime<Utc>,
+    #[serde(default)]
+    pub notification_query_ids: Vec<String>,
 }
 
 impl ScheduledNotificationPluginConfig {
@@ -128,6 +165,7 @@ mod test {
             subject_template: "".to_string(),
             schedule_frequency: "daily".to_string(),
             schedule_start_time: Utc.with_ymd_and_hms(2023, 08, 29, 7, 0, 0).unwrap(),
+            ..Default::default()
         };
 
         let now_utc: DateTime<Utc> = Utc.with_ymd_and_hms(2023, 08, 29, 0, 0, 0).unwrap();
@@ -171,6 +209,7 @@ mod test {
             subject_template: "".to_string(),
             schedule_frequency: "weekly".to_string(),
             schedule_start_time: Utc.with_ymd_and_hms(2023, 08, 29, 7, 0, 0).unwrap(),
+            ..Default::default()
         };
 
         let now_utc: DateTime<Utc> = Utc.with_ymd_and_hms(2023, 08, 29, 0, 0, 0).unwrap();
@@ -197,6 +236,7 @@ mod test {
             subject_template: "".to_string(),
             schedule_frequency: "monthly".to_string(),
             schedule_start_time: Utc.with_ymd_and_hms(2023, 08, 29, 7, 0, 0).unwrap(),
+            ..Default::default()
         };
 
         let now_utc: DateTime<Utc> = Utc.with_ymd_and_hms(2023, 08, 29, 0, 0, 0).unwrap();

--- a/backend/scheduled/src/process.rs
+++ b/backend/scheduled/src/process.rs
@@ -365,7 +365,7 @@ mod test {
 
         assert_eq!(result, ProcessingResult::Success);
 
-        // Query the database to check that we have a notification events for the 1 configured recipient
+        // Query the database to check that we have a notification events
         let repo = NotificationEventRowRepository::new(&service_context.connection);
         let notification_events = repo.un_sent().unwrap();
 
@@ -426,7 +426,7 @@ mod test {
 
         assert_eq!(result, ProcessingResult::Success);
 
-        // Query the database to check that we have a notification events for the 1 configured recipient
+        // Query the database to check that we have a notification events
         let repo = NotificationEventRowRepository::new(&service_context.connection);
         let notification_events = repo.un_sent().unwrap();
 
@@ -495,7 +495,7 @@ mod test {
 
         assert_eq!(result, ProcessingResult::Success); // TODO: This shouldn't be a success I think!
 
-        // Query the database to check that we have no unsent notification events
+        // Query the database to check that we have no unsent notification events (There is a template error so nothing should be sent!)
         let repo = NotificationEventRowRepository::new(&service_context.connection);
         let notification_events = repo.un_sent().unwrap();
 

--- a/backend/scheduled/src/process.rs
+++ b/backend/scheduled/src/process.rs
@@ -126,7 +126,7 @@ fn try_process_scheduled_notifications(
     let sql_query_parameters =
         get_notification_query_results(ctx, &scheduled_notification, &config)?;
 
-    // Template data should include the notification config parameters, plug the results of any queries
+    // Template data should include the notification config parameters, plus the results of any queries
 
     template_params.extend(sql_query_parameters);
 

--- a/backend/scheduled/src/process.rs
+++ b/backend/scheduled/src/process.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use chrono::{DateTime, NaiveDateTime, Utc};
 use repository::{NotificationConfigKind, NotificationConfigRowRepository};
 use service::{
@@ -6,7 +8,10 @@ use service::{
     service_provider::ServiceContext,
 };
 
-use crate::{parse::ScheduledNotificationPluginConfig, NotificationError};
+use crate::{
+    parse::ScheduledNotificationPluginConfig, query::get_notification_query_results,
+    NotificationError,
+};
 
 pub fn process_scheduled_notifications(
     ctx: &ServiceContext,
@@ -104,9 +109,28 @@ fn try_process_scheduled_notifications(
         )));
     }
 
-    // TODO: Run SQL Queries to get the data https://github.com/openmsupply/notify/issues/137
+    let params = match scheduled_notification.parameters.len() {
+        0 => "{}".to_string(),
+        _ => scheduled_notification.parameters.clone(),
+    };
+
+    let mut template_params: HashMap<String, serde_json::Value> = serde_json::from_str(&params)
+        .map_err(|e| {
+            NotificationError::InternalError(format!(
+                "Failed to parse notification parameters: {:?}",
+                e
+            ))
+        })?; // TODO: allow this to be an array rather than just one set of params... https://github.com/openmsupply/notify/issues/194
+
     // Put sql queries and appropriate data into Json Value for template
-    let template_data = serde_json::from_str("{}").map_err(|e| {
+    let sql_query_parameters =
+        get_notification_query_results(ctx, &scheduled_notification, &config)?;
+
+    // Template data should include the notification config parameters, plug the results of any queries
+
+    template_params.extend(sql_query_parameters);
+
+    let template_data = serde_json::to_value(template_params).map_err(|e| {
         NotificationError::InternalError(format!("Failed to parse template data: {:?}", e))
     })?;
 
@@ -137,11 +161,13 @@ mod test {
 
     use chrono::Days;
     use repository::mock::{
-        mock_recipient_a, mock_recipient_list_with_recipient_members_a_and_b,
-        mock_sql_recipient_list_with_no_param, mock_sql_recipient_list_with_param,
+        mock_notification_query_with_params, mock_recipient_a,
+        mock_recipient_list_with_recipient_members_a_and_b, mock_sql_recipient_list_with_no_param,
+        mock_sql_recipient_list_with_param,
     };
     use repository::NotificationEventRowRepository;
     use repository::{mock::MockDataInserts, test_db::setup_all};
+    use service::test_utils::email_test::send_test_emails;
     use service::test_utils::get_test_settings;
 
     use service::service_provider::ServiceProvider;
@@ -200,6 +226,7 @@ mod test {
             subject_template: "TestSubject".to_string(),
             schedule_frequency: "daily".to_string(),
             schedule_start_time: Utc::now().checked_sub_days(Days::new(1)).unwrap(),
+            ..Default::default()
         };
 
         // Create a notification config with a recipient list
@@ -255,6 +282,7 @@ mod test {
             subject_template: "TestSubject".to_string(),
             schedule_frequency: "daily".to_string(),
             schedule_start_time: Utc::now().checked_sub_days(Days::new(1)).unwrap(),
+            ..Default::default()
         };
 
         // Create a notification config with a recipient list
@@ -308,6 +336,7 @@ mod test {
             subject_template: "TestSubject".to_string(),
             schedule_frequency: "daily".to_string(),
             schedule_start_time: Utc::now().checked_sub_days(Days::new(1)).unwrap(),
+            ..Default::default()
         };
 
         // Create a notification config with 2 sql recipient lists
@@ -341,5 +370,135 @@ mod test {
         let notification_events = repo.un_sent().unwrap();
 
         assert_eq!(notification_events.len(), 2);
+    }
+
+    // Test that we get a notification when we have a sql recipient list & notification query
+    #[tokio::test]
+    async fn test_try_process_scheduled_notifications_with_queries() {
+        let (_, _, connection_manager, _) = setup_all(
+            "test_try_process_scheduled_notifications_with_queries",
+            MockDataInserts::none()
+                .sql_recipient_lists()
+                .notification_queries(),
+        )
+        .await;
+
+        let service_provider = Arc::new(ServiceProvider::new(
+            connection_manager,
+            get_test_settings(""),
+        ));
+
+        let service_context = ServiceContext::new(service_provider).unwrap();
+
+        // Daily Scheduled Notification that started this time yesterday
+        let sch_config = ScheduledNotificationPluginConfig {
+            body_template: "Sensor Limit {{ sensor_limit }}, Latest Temperature: {{ latest_temperature }}, is over limit ? {{ query1.0.is_above_limit }}".to_string(),
+            subject_template: "Sensor Data".to_string(),
+            schedule_frequency: "daily".to_string(),
+            schedule_start_time: Utc::now().checked_sub_days(Days::new(1)).unwrap(),
+            notification_query_ids: vec![mock_notification_query_with_params().id],
+            ..Default::default()
+        };
+
+        // Create a notification config with 2 sql recipient lists
+        let notification_config = NotificationConfig {
+            id: "notification_config_1".to_string(),
+            kind: NotificationConfigKind::Scheduled,
+            recipient_ids: vec![],
+            recipient_list_ids: vec![],
+            sql_recipient_list_ids: vec![
+                mock_sql_recipient_list_with_no_param().id,
+                mock_sql_recipient_list_with_param().id,
+            ],
+            parameters: "{ \"email_address\": \"test-user@example.com\",\"sensor_limit\": \"8\", \"latest_temperature\": \"8.5\"}".to_string(),
+            next_due_datetime: Some(chrono::Utc::now().naive_utc()),
+            configuration_data: serde_json::to_string(&sch_config).unwrap(),
+            ..Default::default()
+        };
+
+        // Try to process the notification (Should be due now)
+        let result = try_process_scheduled_notifications(
+            &service_context,
+            notification_config,
+            chrono::Utc::now().naive_utc(),
+        )
+        .unwrap();
+
+        assert_eq!(result, ProcessingResult::Success);
+
+        // Query the database to check that we have a notification events for the 1 configured recipient
+        let repo = NotificationEventRowRepository::new(&service_context.connection);
+        let notification_events = repo.un_sent().unwrap();
+
+        assert_eq!(notification_events.len(), 2);
+
+        assert_eq!(
+            notification_events[0].message,
+            "Sensor Limit 8, Latest Temperature: 8.5, is over limit ? true"
+        );
+
+        send_test_notifications(&service_context).await;
+        send_test_emails(&service_context);
+    }
+
+    // Test that we don't send notifications if template fails to render
+    #[tokio::test]
+    async fn test_try_process_scheduled_notifications_with_template_error() {
+        let (_, _, connection_manager, _) = setup_all(
+            "test_try_process_scheduled_notifications_with_template_error",
+            MockDataInserts::none()
+                .sql_recipient_lists()
+                .notification_queries(),
+        )
+        .await;
+
+        let service_provider = Arc::new(ServiceProvider::new(
+            connection_manager,
+            get_test_settings(""),
+        ));
+
+        let service_context = ServiceContext::new(service_provider).unwrap();
+
+        // Daily Scheduled Notification that started this time yesterday
+        let sch_config = ScheduledNotificationPluginConfig {
+            body_template: "Sensor Limit {{ sensor_limit }}, Latest Temperature: {{ latest_temperature }}, is over limit ? {{ query1.is_above_limit }}".to_string(), // This will cause a template render error, Need to get the first query row with .0
+            subject_template: "Sensor Data".to_string(),
+            schedule_frequency: "daily".to_string(),
+            schedule_start_time: Utc::now().checked_sub_days(Days::new(1)).unwrap(),
+            notification_query_ids: vec![mock_notification_query_with_params().id],
+            ..Default::default()
+        };
+
+        // Create a notification config with 2 sql recipient lists
+        let notification_config = NotificationConfig {
+            id: "notification_config_1".to_string(),
+            kind: NotificationConfigKind::Scheduled,
+            recipient_ids: vec![],
+            recipient_list_ids: vec![],
+            sql_recipient_list_ids: vec![
+                mock_sql_recipient_list_with_no_param().id,
+                mock_sql_recipient_list_with_param().id,
+            ],
+            parameters: "{ \"email_address\": \"test-user@example.com\",\"sensor_limit\": \"8\", \"latest_temperature\": \"8.5\"}".to_string(),
+            next_due_datetime: Some(chrono::Utc::now().naive_utc()),
+            configuration_data: serde_json::to_string(&sch_config).unwrap(),
+            ..Default::default()
+        };
+
+        // Try to process the notification (Should be due now)
+        let result = try_process_scheduled_notifications(
+            &service_context,
+            notification_config,
+            chrono::Utc::now().naive_utc(),
+        )
+        .unwrap();
+
+        assert_eq!(result, ProcessingResult::Success); // TODO: This shouldn't be a success I think!
+
+        // Query the database to check that we have no unsent notification events
+        let repo = NotificationEventRowRepository::new(&service_context.connection);
+        let notification_events = repo.un_sent().unwrap();
+
+        assert_eq!(notification_events.len(), 0);
     }
 }

--- a/backend/scheduled/src/query.rs
+++ b/backend/scheduled/src/query.rs
@@ -1,0 +1,295 @@
+use std::collections::HashMap;
+
+use repository::{EqualFilter, NotificationQueryFilter, NotificationQueryRepository};
+use serde_json::json;
+use service::{notification_config::query::NotificationConfig, service_provider::ServiceContext};
+
+use crate::{parse::ScheduledNotificationPluginConfig, NotificationError};
+
+pub fn get_notification_query_results(
+    ctx: &ServiceContext,
+    notification_config: &NotificationConfig,
+    config: &ScheduledNotificationPluginConfig,
+) -> Result<HashMap<String, serde_json::Value>, NotificationError> {
+    let mut query_results = HashMap::new();
+
+    // get all the configured queries
+
+    let notification_config_repo = NotificationQueryRepository::new(&ctx.connection);
+
+    let queries = notification_config_repo
+        .query_by_filter(NotificationQueryFilter::new().id(EqualFilter::equal_any(
+            config.notification_query_ids.clone(),
+        )))
+        .map_err(|e| {
+            NotificationError::InternalError(format!("Unable to get notification queries: {:?}", e))
+        })?;
+
+    // loop through all the notification query ids, run them, and store the results
+    for query in queries {
+        let result = ctx
+            .service_provider
+            .datasource_service
+            .run_sql_query_with_parameters(
+                query.query.clone(),
+                notification_config.parameters.clone(),
+            );
+        let query_json = match result {
+            Ok(result) => serde_json::from_str(&result)
+                .unwrap_or_else(|_| json!([{"error": "Unable to parse query result"}])),
+            Err(e) => {
+                log::error!(
+                    "Error running query {} for notification {}: {:?}",
+                    query.reference_name,
+                    notification_config.title,
+                    e
+                );
+                json!([{"error": "error running query", "query": query.query, "parameters": notification_config.parameters}])
+            }
+        };
+        query_results.insert(query.reference_name, query_json);
+    }
+
+    Ok(query_results)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use repository::{
+        mock::{
+            mock_notification_query_with_no_param_2_rows, mock_notification_query_with_params,
+            MockDataInserts,
+        },
+        test_db::setup_all,
+        NotificationConfigStatus,
+    };
+    use util::uuid::uuid;
+
+    use service::{service_provider::ServiceProvider, test_utils::get_test_settings};
+
+    use super::*;
+
+    // Test that we get the correct results when we have a notification query with no parameters
+    #[tokio::test]
+    async fn test_get_notification_query_results_no_param() {
+        let (_, _, connection_manager, _) = setup_all(
+            "test_get_notification_query_results_no_param",
+            MockDataInserts::none().notification_queries(),
+        )
+        .await;
+        let service_provider = Arc::new(ServiceProvider::new(
+            connection_manager,
+            get_test_settings(""),
+        ));
+        let context = ServiceContext::as_server_admin(service_provider).unwrap();
+
+        // There are two mock notifications, one with a parameters and one without
+
+        // 1. Check we get the result with 1 query and no parameters
+
+        // Create a notification config with no params to use
+        let notification_config = NotificationConfig {
+            id: uuid(),
+            parameters: "{}".to_string(),
+            status: NotificationConfigStatus::Enabled,
+            ..Default::default()
+        };
+
+        let config = ScheduledNotificationPluginConfig {
+            notification_query_ids: vec![mock_notification_query_with_no_param_2_rows().id],
+            ..Default::default()
+        };
+
+        // Call the function being tested
+        let query_results =
+            get_notification_query_results(&context, &notification_config, &config).unwrap();
+
+        let result_key = mock_notification_query_with_no_param_2_rows().reference_name;
+
+        // Check we got the result we expected
+        assert_eq!(
+            query_results.get(&result_key).unwrap(),
+            &json!([
+                {
+                    "latest_temperature": 1.25,
+                    "sensor_name": "sensor1",
+                    "sensor_limit": -10
+                },
+                {
+                    "latest_temperature": 1.51,
+                    "sensor_name": "sensor2",
+                    "sensor_limit": -10
+                }
+            ])
+        );
+    }
+
+    // Test that we get the correct results when we have a notification query with parameters
+    #[tokio::test]
+    async fn test_get_notification_query_results_params() {
+        let (_, _, connection_manager, _) = setup_all(
+            "test_get_notification_query_results_params",
+            MockDataInserts::none().notification_queries(),
+        )
+        .await;
+        let service_provider = Arc::new(ServiceProvider::new(
+            connection_manager,
+            get_test_settings(""),
+        ));
+        let context = ServiceContext::as_server_admin(service_provider).unwrap();
+
+        // There are two mock notifications, one with a parameters and one without
+
+        // 2. Check we get the result with 1 query and parameters (sensor_limit and latest_temperature)
+
+        // Create a notification config with the correct params
+        let notification_config = NotificationConfig {
+            id: uuid(),
+            parameters: "{\"sensor_limit\": \"8\", \"latest_temperature\": \"8.5\"}".to_string(),
+            status: NotificationConfigStatus::Enabled,
+            ..Default::default()
+        };
+
+        let config = ScheduledNotificationPluginConfig {
+            notification_query_ids: vec![mock_notification_query_with_params().id],
+            ..Default::default()
+        };
+
+        // Call the function being tested
+        let query_results =
+            get_notification_query_results(&context, &notification_config, &config).unwrap();
+
+        let result_key = mock_notification_query_with_params().reference_name;
+
+        // Check we got the result we expected
+        assert_eq!(
+            query_results.get(&result_key).unwrap(),
+            &json!([
+                {
+                    "latest_temperature": 8.5,
+                    "sensor_limit": 8,
+                    "is_above_limit": true,
+                }
+            ])
+        );
+    }
+
+    // Test that we get the correct results when we have a 2 notification queries, one with parameters and one without
+    #[tokio::test]
+    async fn test_get_notification_query_results_2_queries() {
+        let (_, _, connection_manager, _) = setup_all(
+            "test_get_notification_query_results_2_queries",
+            MockDataInserts::none().notification_queries(),
+        )
+        .await;
+        let service_provider = Arc::new(ServiceProvider::new(
+            connection_manager,
+            get_test_settings(""),
+        ));
+        let context = ServiceContext::as_server_admin(service_provider).unwrap();
+
+        // There are two mock notifications, one with a parameters and one without
+
+        // 3. Check we get the results with 2 queries and parameters (sensor_limit and latest_temperature)
+
+        // Create a notification config
+        let notification_config = NotificationConfig {
+            id: uuid(),
+            parameters: "{\"sensor_limit\": \"8\", \"latest_temperature\": \"8.5\"}".to_string(),
+            status: NotificationConfigStatus::Enabled,
+            ..Default::default()
+        };
+
+        let config = ScheduledNotificationPluginConfig {
+            notification_query_ids: vec![
+                mock_notification_query_with_params().id,
+                mock_notification_query_with_no_param_2_rows().id,
+            ],
+            ..Default::default()
+        };
+
+        // Call the function being tested
+        let query_results =
+            get_notification_query_results(&context, &notification_config, &config).unwrap();
+
+        // Check we got the 2 results we expected
+        assert_eq!(query_results.len(), 2);
+
+        let result_key = mock_notification_query_with_params().reference_name;
+
+        // Check we got the result we expected for the first query
+        assert_eq!(
+            query_results.get(&result_key).unwrap(),
+            &json!([
+                {
+                    "latest_temperature": 8.5,
+                    "sensor_limit": 8,
+                    "is_above_limit": true,
+                }
+            ])
+        );
+
+        let result_key = mock_notification_query_with_no_param_2_rows().reference_name;
+
+        // Check we got the result we expected for the second query
+        assert_eq!(
+            query_results.get(&result_key).unwrap(),
+            &json!([
+                {
+                    "latest_temperature": 1.25,
+                    "sensor_name": "sensor1",
+                    "sensor_limit": -10
+                },
+                {
+                    "latest_temperature": 1.51,
+                    "sensor_name": "sensor2",
+                    "sensor_limit": -10
+                }
+            ])
+        );
+    }
+
+    // Test we get an error back if we try to run a query missing it's parameters
+    #[tokio::test]
+    async fn test_get_notification_query_results_missing_params() {
+        let (_, _, connection_manager, _) = setup_all(
+            "test_get_notification_query_results_missing_params",
+            MockDataInserts::none().notification_queries(),
+        )
+        .await;
+        let service_provider = Arc::new(ServiceProvider::new(
+            connection_manager,
+            get_test_settings(""),
+        ));
+        let context = ServiceContext::as_server_admin(service_provider).unwrap();
+
+        // There are two mock notifications, one with a parameters and one without
+
+        // 4. Check we get an error if we try to run a query missing it's parameters
+
+        // Create a notification config with no params to use
+        let notification_config = NotificationConfig {
+            id: uuid(),
+            parameters: "{}".to_string(),
+            status: NotificationConfigStatus::Enabled,
+            ..Default::default()
+        };
+
+        let config = ScheduledNotificationPluginConfig {
+            notification_query_ids: vec![mock_notification_query_with_params().id],
+            ..Default::default()
+        };
+
+        // Call the function being tested
+        let result =
+            get_notification_query_results(&context, &notification_config, &config).unwrap();
+
+        // Check we got the error we expected
+        assert_eq!(
+            result.get("query1").unwrap()[0]["error"].as_str().unwrap(),
+            "error running query"
+        );
+    }
+}

--- a/backend/service/src/notification/enqueue.rs
+++ b/backend/service/src/notification/enqueue.rs
@@ -129,7 +129,7 @@ pub fn create_notification_events(
             Err(e) => {
                 log::error!("Failed to render notification title template: {:?}", e);
                 NotificationEventRow {
-                    status: NotificationEventStatus::Errored,
+                    status: NotificationEventStatus::Failed,
                     error_message: Some(format!("{:?}", e)),
                     ..base_row
                 }
@@ -144,7 +144,7 @@ pub fn create_notification_events(
             Err(e) => {
                 log::error!("Failed to render notification body template: {:?}", e);
                 NotificationEventRow {
-                    status: NotificationEventStatus::Errored,
+                    status: NotificationEventStatus::Failed, // Failed means this message will not be sent
                     error_message: Some(format!("{:?}", e)),
                     ..base_row_with_title
                 }
@@ -201,15 +201,17 @@ mod test {
                 body_template: TemplateDefinition::TemplateName(
                     "test_message/email.html".to_string(),
                 ),
-                recipients: vec![NotificationTarget {
-                    name: "test".to_string(),
-                    to_address: "test@example.com".to_string(),
-                    notification_type: NotificationType::Email,
-                }, NotificationTarget {
-                    name: "test2".to_string(),
-                    to_address: "test@example.com".to_string(),
-                    notification_type: NotificationType::Email,
-                },
+                recipients: vec![
+                    NotificationTarget {
+                        name: "test".to_string(),
+                        to_address: "test@example.com".to_string(),
+                        notification_type: NotificationType::Email,
+                    },
+                    NotificationTarget {
+                        name: "test2".to_string(),
+                        to_address: "test@example.com".to_string(),
+                        notification_type: NotificationType::Email,
+                    },
                 ],
                 template_data: serde_json::json!({}),
             },
@@ -252,15 +254,18 @@ mod test {
                 body_template: TemplateDefinition::TemplateName(
                     "test_message/telegram.html".to_string(),
                 ),
-                recipients: vec![NotificationTarget {
-                    name: "telegram".to_string(),
-                    to_address: "-12345".to_string(),
-                    notification_type: NotificationType::Telegram,
-                }, NotificationTarget {
-                    name: "telegram2".to_string(),
-                    to_address: "-12345".to_string(),
-                    notification_type: NotificationType::Telegram,
-                }],
+                recipients: vec![
+                    NotificationTarget {
+                        name: "telegram".to_string(),
+                        to_address: "-12345".to_string(),
+                        notification_type: NotificationType::Telegram,
+                    },
+                    NotificationTarget {
+                        name: "telegram2".to_string(),
+                        to_address: "-12345".to_string(),
+                        notification_type: NotificationType::Telegram,
+                    },
+                ],
                 template_data: serde_json::json!({}),
             },
         );

--- a/backend/service/src/notification_config/recipients.rs
+++ b/backend/service/src/notification_config/recipients.rs
@@ -74,7 +74,6 @@ pub fn get_notification_targets(
                 notification_targets.extend(sql_recipients);
             }
             Err(err) => {
-                println!("err: {:?}", err);
                 log::error!(
                     "Error running SQL Recipient List query: {:?}, skipping this recipient list",
                     err


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Closes #137 

# 👩🏻‍💻 What does this PR do?
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

Runs any configured queries and makes their data available in the rendering of the template.

# 🧪 How has/should this change been tested?
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Create a query which returns known data.
Create a notification config for a scheduled report

Add you query and update the body template to include data based on the reference name.

Could be something like this...

Query (last_10_temperature_logs):
```
SELECT s.name, tl.temperature, "time", "date"
FROM temperature_log tl
JOIN sensor s ON tl.sensor_id = s.id
ORDER BY date desc, time desc
LIMIT 10
```

Template (first record)

```
Sensor:  {{ last_10_temperature_logs.0.name }} Temperature {{ last_10_temperature_logs.0.temperature }}
```

Template all 10 records

```
{% for row in last_10_temperature_logs %}
{{row.name}}: {{row.temperature}}
{% endfor %}
```

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->

Right now this is a nightmare to get setup and test with anything complicated, see https://github.com/openmsupply/notify/issues/65 for some ideas there.