### PR TITLE
Logging configuration from open-mSupply

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ backend/certs_disabled/
 backend/.vscode/settings.json
 .DS_store
 .tmp/
+backend/log

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -395,6 +395,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33954243bd79057c2de7338850b85983a44588021f8a5fee574a8888c6de4344"
 
 [[package]]
+name = "arc-swap"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dabe5a181f83789739c194cbe5a897dde195078fac08568d09221fd6137a7ba8"
+
+[[package]]
 name = "ascii_utils"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,7 +681,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.7.1",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
@@ -978,6 +984,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "convert_case"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4a24b1aaf0fd0ce8b45161144d6f42cd91677fd5940fd431183eb023b3a2b8"
+
+[[package]]
 name = "cookie"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,7 +1157,7 @@ version = "0.99.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1296,30 +1308,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
-name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "errno"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,12 +1386,12 @@ checksum = "4d3d6188b8804df28032815ea256b6955c9625c24da7525f387a7af02fbb8f01"
 
 [[package]]
 name = "flate2"
-version = "1.0.24"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.5.4",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1889,15 +1877,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "hostname"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1956,9 +1935,12 @@ checksum = "02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026"
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
+]
 
 [[package]]
 name = "hyper"
@@ -2085,32 +2067,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7d367024b3f3414d8e01f437f704f41a9f64ab36f9067fa73e526ad4c763c87"
-dependencies = [
- "libc",
- "windows-sys 0.42.0",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.0"
+name = "is_debug"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae5bc6e2eb41c9def29a3e0f1306382807764b9b53112030eff57435667352d"
-dependencies = [
- "hermit-abi 0.2.6",
- "io-lifetimes",
- "rustix 0.36.3",
- "windows-sys 0.42.0",
-]
+checksum = "06d198e9919d9822d5f7083ba8530e04de87841eaf21ead9af8f2304efd57c89"
 
 [[package]]
 name = "itoa"
@@ -2244,12 +2210,6 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
@@ -2287,7 +2247,38 @@ version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 dependencies = [
+ "serde",
  "value-bag",
+]
+
+[[package]]
+name = "log-mdc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
+
+[[package]]
+name = "log4rs"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1ad45e4584824d760c35d71868dd7e6e5acd8f5195a9573743b369fc86cd6"
+dependencies = [
+ "arc-swap",
+ "chrono",
+ "flate2",
+ "fnv",
+ "humantime",
+ "libc",
+ "log",
+ "log-mdc",
+ "parking_lot 0.11.2",
+ "serde",
+ "serde-value",
+ "serde_derive",
+ "serde_json",
+ "serde_yaml",
+ "thread-id",
+ "winapi",
 ]
 
 [[package]]
@@ -2365,15 +2356,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
-dependencies = [
- "adler",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -2509,7 +2491,7 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi",
  "libc",
 ]
 
@@ -2586,6 +2568,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "ordered-float"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2836,6 +2827,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quickcheck"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2899,6 +2896,12 @@ checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
@@ -3099,28 +3102,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b1fbb4dfc4eb1d390c02df47760bb19a84bb80b301ecc947ab5406394d8223e"
-dependencies = [
- "bitflags 1.3.2",
- "errno 0.2.8",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.1.3",
- "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "rustix"
 version = "0.38.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
 dependencies = [
  "bitflags 2.4.0",
- "errno 0.3.2",
+ "errno",
  "libc",
- "linux-raw-sys 0.4.5",
+ "linux-raw-sys",
  "windows-sys 0.48.0",
 ]
 
@@ -3245,6 +3234,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a65a7291a8a568adcae4c10a677ebcedbc6c9cec91c054dee2ce40b0e3290eb"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3279,6 +3278,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+dependencies = [
+ "indexmap",
+ "ryu",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "server"
 version = "0.1.0"
 dependencies = [
@@ -3290,7 +3301,6 @@ dependencies = [
  "coldchain",
  "config",
  "datasource",
- "env_logger",
  "futures-util",
  "graphql",
  "graphql_core",
@@ -3303,6 +3313,7 @@ dependencies = [
  "scheduled",
  "serde",
  "service",
+ "simple-log",
  "telegram",
  "tokio",
  "util",
@@ -3318,6 +3329,7 @@ dependencies = [
  "bcrypt",
  "chrono",
  "datasource",
+ "flate2",
  "jsonwebtoken",
  "lettre",
  "log",
@@ -3326,6 +3338,7 @@ dependencies = [
  "repository",
  "serde",
  "serde_json",
+ "simple-log",
  "telegram",
  "tera",
  "tokio",
@@ -3373,6 +3386,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "simple-log"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "110feefe2a808cadb7fe8c07c615ac82e899f1795fec063ed2fb1d72de5d417b"
+dependencies = [
+ "convert_case 0.5.0",
+ "is_debug",
+ "log",
+ "log4rs",
+ "once_cell",
+ "serde",
 ]
 
 [[package]]
@@ -3497,7 +3524,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.0.0",
  "redox_syscall 0.3.5",
- "rustix 0.38.8",
+ "rustix",
  "windows-sys 0.48.0",
 ]
 
@@ -3550,6 +3577,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.37",
+]
+
+[[package]]
+name = "thread-id"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fbf4c9d56b320106cd64fd024dadfa0be7cb4706725fc44a7d7ce952d820c1"
+dependencies = [
+ "libc",
+ "redox_syscall 0.1.57",
+ "winapi",
 ]
 
 [[package]]
@@ -4083,21 +4121,6 @@ dependencies = [
  "windows_i686_msvc 0.32.0",
  "windows_x86_64_gnu 0.32.0",
  "windows_x86_64_msvc 0.32.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]

--- a/backend/README.md
+++ b/backend/README.md
@@ -83,4 +83,8 @@ Notify is designed to run behind a SSL proxy such as [Caddy](https://caddyserver
 
 > WARNING: DO NOT RUN THIS IN PRODUCTION WITHOUT SSL!
 
-## Deployment
+# Logging
+
+By default, the server logs to console with a logging level of `Info`
+You can configure this, to log to a file, for example, with a rollover of log files based on file size.
+See the `example.yaml` file for the available options.

--- a/backend/configuration/base.yaml
+++ b/backend/configuration/base.yaml
@@ -21,3 +21,9 @@ datasource:
   username: "postgres"
   password: "password"
   database_name: "dashboard"
+logging:
+  mode: "All"
+  level: "Info"
+  filename: "notify.log"
+  max_file_size: 1
+  max_file_count: 1

--- a/backend/configuration/example.yaml
+++ b/backend/configuration/example.yaml
@@ -1,3 +1,5 @@
+# To use custom server settings for a local or a production environment create a copy
+# of this example file and name it local.yaml
 server:
   host: 127.0.0.1
   app_url: "http://localhost:3007"
@@ -9,3 +11,12 @@ datasource:
   username: "postgres"
   password: "password"
   database_name: "dashboard"
+# logging:
+##   one of: All | Console | File
+#   mode: Console
+##   one of:  Error | Warn | Info (default) | Debug | Trace
+#   level: Info
+#   directory: log
+#   filename: notify.log
+#   max_file_count: 10
+#   max_file_size: 1

--- a/backend/repository/src/db_diesel/key_value_store.rs
+++ b/backend/repository/src/db_diesel/key_value_store.rs
@@ -20,6 +20,9 @@ table! {
 #[DbValueStyle = "SCREAMING_SNAKE_CASE"]
 pub enum KeyValueType {
     SettingsTokenSecret,
+    LogLevel,
+    LogDirectory,
+    LogFileName,
 }
 
 #[derive(Clone, Queryable, Insertable, AsChangeset, Debug, PartialEq)]

--- a/backend/server/Cargo.toml
+++ b/backend/server/Cargo.toml
@@ -49,13 +49,13 @@ actix-http ="3.3.1"
 actix-multipart = "0.4"
 actix-files = "0.6.0"
 config = "0.13"
-env_logger = "0.10"
 log = "0.4.14"
 serde = "1.0.137"
 tokio = { version = "1.29", features = ["macros" ] }
 rust-embed = "6.4.2"
 mime_guess = "2.0.4"
 futures-util = "0.3"
+simple-log = { version = "1.6" }
 sanitize-filename = "0.4"
 
 

--- a/backend/server/src/logging.rs
+++ b/backend/server/src/logging.rs
@@ -1,0 +1,56 @@
+use std::env;
+
+use service::settings::{Level, LogMode, LoggingSettings};
+use simple_log::LogConfigBuilder;
+
+// Can use log4rs to extend logging functionality beyond what is available in current
+// log crate since simple-log is based on log4rs.
+pub fn logging_init(settings: Option<LoggingSettings>, level: Option<Level>) {
+    let settings = settings.unwrap_or(LoggingSettings::new(
+        LogMode::Console,
+        service::settings::Level::Info,
+    ));
+
+    let log_level = level.unwrap_or(settings.level.clone());
+    let config = match settings.mode {
+        LogMode::File => file_logger(&settings)
+            .level(log_level.to_string())
+            .output_file()
+            .build(),
+        LogMode::Console => LogConfigBuilder::builder()
+            .level(log_level.to_string())
+            .output_console()
+            .build(),
+        LogMode::All => file_logger(&settings).level(log_level.to_string()).build(),
+    };
+
+    simple_log::new(config).expect("Unable to initialise logger");
+}
+
+fn file_logger(settings: &LoggingSettings) -> LogConfigBuilder {
+    let default_log_file = "notify.log".to_string();
+    let default_log_dir = "log".to_string();
+    let default_max_file_count = 10;
+    let default_max_file_size = 1;
+
+    // Note: the file_split will panic if the path separator isn't appended
+    // and the path separator has to be unix-style, even on windows
+    let log_dir = format!("{}/", settings.directory.clone().unwrap_or(default_log_dir),);
+    #[cfg(not(android))]
+    let log_path = env::current_dir().unwrap_or_default().join(&log_dir);
+    // We are given the full path when running on android
+    #[cfg(android)]
+    let log_path = std::path::PathBuf::from(&log_dir);
+    let log_file = settings
+        .filename
+        .clone()
+        .unwrap_or_else(|| default_log_file);
+    let log_file = log_path.join(log_file).to_string_lossy().to_string();
+    let max_file_count = settings.max_file_count.unwrap_or(default_max_file_count);
+    let max_file_size = settings.max_file_size.unwrap_or(default_max_file_size);
+
+    LogConfigBuilder::builder()
+        .path(&log_file)
+        .size(max_file_size as u64)
+        .roll_count(max_file_count as u32)
+}

--- a/backend/server/src/main.rs
+++ b/backend/server/src/main.rs
@@ -1,20 +1,14 @@
 #![allow(where_clauses_object_safety)]
 
-use std::env;
-
-use server::{configuration, start_server};
+use server::{configuration, logging::logging_init, start_server};
 use service::settings::Settings;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    if env::var("RUST_LOG").is_err() {
-        //Default rust log level to info
-        env::set_var("RUST_LOG", "info");
-    }
-    env_logger::init();
-
     let settings: Settings =
         configuration::get_configuration().expect("Failed to parse configuration settings");
+
+    logging_init(settings.logging.clone(), None);
 
     let off_switch = tokio::sync::mpsc::channel(1).1;
     start_server(settings, off_switch).await

--- a/backend/service/Cargo.toml
+++ b/backend/service/Cargo.toml
@@ -25,6 +25,8 @@ rand = "0.8"
 tera = "1"
 nanohtml2text = "0.1"
 async-trait = "0.1.30"
+flate2 = "1.0.26"
+simple-log = { version = "1.6" }
 
 [dev-dependencies]
 actix-rt = "2.6.0"

--- a/backend/service/src/lib.rs
+++ b/backend/service/src/lib.rs
@@ -6,6 +6,7 @@ pub mod auth;
 pub mod auth_data;
 pub mod datasource;
 pub mod email;
+pub mod log_service;
 pub mod login;
 pub mod notification;
 pub mod notification_config;

--- a/backend/service/src/log_service.rs
+++ b/backend/service/src/log_service.rs
@@ -1,0 +1,143 @@
+use anyhow::Error;
+use flate2::read::GzDecoder;
+use repository::{KeyValueStoreRepository, KeyValueType, RepositoryError};
+use std::{
+    fs::{self, File},
+    io::Read,
+    path::Path,
+};
+
+use crate::{service_provider::ServiceContext, settings::Level};
+
+pub trait LogServiceTrait: Send + Sync {
+    fn get_log_file_names(&self, ctx: &ServiceContext) -> Result<Vec<String>, Error> {
+        let log_dir = self.get_log_directory(ctx)?;
+        let log_dir_path = Path::new(&log_dir);
+        let mut log_file_names = Vec::new();
+
+        for entry in fs::read_dir(log_dir_path)? {
+            let path = entry?.path();
+            log_file_names.push(path.file_name().unwrap().to_string_lossy().to_string());
+        }
+
+        Ok(log_file_names)
+    }
+
+    fn get_log_content(
+        &self,
+        ctx: &ServiceContext,
+        file_name: Option<String>,
+    ) -> Result<(String, Vec<String>), Error> {
+        let log_dir = self.get_log_directory(ctx)?;
+        let log_dir_path = Path::new(&log_dir);
+        let default_filename = self.get_log_file_name(ctx)?;
+
+        let file_name = match file_name {
+            Some(file_name) => file_name,
+            None => default_filename,
+        };
+        let log_file_path = log_dir_path.join(&file_name);
+
+        let log_file_content = if file_name.ends_with(".gz") {
+            let mut decompressed: String = Default::default();
+            let mut decoder = GzDecoder::new(File::open(log_file_path)?);
+            decoder.read_to_string(&mut decompressed)?;
+
+            decompressed
+        } else {
+            fs::read_to_string(log_file_path)?
+        };
+
+        let log_file_content = log_file_content
+            .split("\n")
+            .map(|s| s.to_string())
+            .collect::<Vec<String>>();
+
+        Ok((file_name, log_file_content))
+    }
+
+    fn get_log_level(&self, ctx: &ServiceContext) -> Result<Option<Level>, RepositoryError> {
+        let key_value_store = KeyValueStoreRepository::new(&ctx.connection);
+
+        let log_level = key_value_store.get_string(KeyValueType::LogLevel)?;
+
+        let level = match log_level {
+            Some(log_level) => match log_level.as_str() {
+                "error" => Some(Level::Error),
+                "warn" => Some(Level::Warn),
+                "info" => Some(Level::Info),
+                "debug" => Some(Level::Debug),
+                "trace" => Some(Level::Trace),
+                _ => None,
+            },
+            None => None,
+        };
+
+        Ok(level)
+    }
+
+    fn update_log_level(
+        &self,
+        ctx: &ServiceContext,
+        log_level: Level,
+    ) -> Result<(), RepositoryError> {
+        let key_value_store = KeyValueStoreRepository::new(&ctx.connection);
+
+        let log_level = match log_level {
+            Level::Error => "error",
+            Level::Warn => "warn",
+            Level::Info => "info",
+            Level::Debug => "debug",
+            Level::Trace => "trace",
+        };
+
+        key_value_store.set_string(KeyValueType::LogLevel, Some(log_level.to_string()))?;
+        simple_log::update_log_level(log_level).expect("Couldn't update log level");
+
+        Ok(())
+    }
+
+    fn get_log_directory(&self, ctx: &ServiceContext) -> Result<String, RepositoryError> {
+        let key_value_store = KeyValueStoreRepository::new(&ctx.connection);
+
+        let log_directory = key_value_store.get_string(KeyValueType::LogDirectory)?;
+
+        Ok(log_directory.unwrap_or(Default::default()))
+    }
+
+    fn set_log_directory(
+        &self,
+        ctx: &ServiceContext,
+        log_directory: Option<String>,
+    ) -> Result<(), RepositoryError> {
+        let key_value_store = KeyValueStoreRepository::new(&ctx.connection);
+
+        key_value_store.set_string(KeyValueType::LogDirectory, log_directory)?;
+
+        Ok(())
+    }
+
+    fn get_log_file_name(&self, ctx: &ServiceContext) -> Result<String, RepositoryError> {
+        let key_value_store = KeyValueStoreRepository::new(&ctx.connection);
+
+        let log_file_name = key_value_store.get_string(KeyValueType::LogFileName)?;
+
+        Ok(log_file_name.unwrap_or(Default::default()))
+    }
+
+    fn set_log_file_name(
+        &self,
+        ctx: &ServiceContext,
+        log_file_name: Option<String>,
+    ) -> Result<(), RepositoryError> {
+        let key_value_store = KeyValueStoreRepository::new(&ctx.connection);
+
+        key_value_store.set_string(KeyValueType::LogFileName, log_file_name)?;
+
+        Ok(())
+    }
+}
+
+pub struct LogService {}
+
+impl LogServiceTrait for LogService {}

--- a/backend/service/src/service_provider.rs
+++ b/backend/service/src/service_provider.rs
@@ -7,6 +7,7 @@ use crate::{
     auth::{AuthService, AuthServiceTrait},
     datasource::{DatasourceService, DatasourceServiceTrait},
     email::{EmailService, EmailServiceTrait},
+    log_service::{LogService, LogServiceTrait},
     notification::{NotificationService, NotificationServiceTrait},
     notification_config::{NotificationConfigService, NotificationConfigServiceTrait},
     notification_query::{NotificationQueryService, NotificationQueryServiceTrait},
@@ -33,6 +34,7 @@ pub struct ServiceProvider {
     pub plugin_service: Box<dyn PluginServiceTrait>,
     pub settings: Settings,
     pub telegram: Option<TelegramClient>,
+    pub log_service: Box<dyn LogServiceTrait>,
 }
 
 pub struct ServiceContext {
@@ -97,6 +99,7 @@ impl ServiceProvider {
             plugin_service: Box::new(PluginService {}),
             settings,
             telegram,
+            log_service: Box::new(LogService {}),
         }
     }
 

--- a/backend/service/src/settings.rs
+++ b/backend/service/src/settings.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Display, Formatter, Result};
+
 use datasource::database_settings::PostgresSettings;
 use repository::database_settings::SqliteSettings;
 #[derive(serde::Deserialize, Clone)]
@@ -7,6 +9,7 @@ pub struct Settings {
     pub mail: MailSettings,
     pub telegram: TelegramSettings,
     pub datasource: PostgresSettings,
+    pub logging: Option<LoggingSettings>,
 }
 
 #[derive(serde::Deserialize, Clone)]
@@ -30,6 +33,67 @@ impl ServerSettings {
 pub fn is_develop() -> bool {
     // debug_assertions is the recommended way to check if we are in 'dev' mode
     cfg!(debug_assertions)
+}
+
+#[derive(serde::Deserialize, Clone)]
+pub enum LogMode {
+    All,
+    Console,
+    File,
+}
+
+#[derive(serde::Deserialize, Clone, Debug)]
+pub enum Level {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl Display for Level {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        let level = match self {
+            Level::Error => "error",
+            Level::Warn => "warn",
+            Level::Info => "info",
+            Level::Debug => "debug",
+            Level::Trace => "trace",
+        };
+        write!(f, "{}", level)
+    }
+}
+
+#[derive(serde::Deserialize, Clone)]
+pub struct LoggingSettings {
+    /// Console (default) | File
+    pub mode: LogMode,
+    ///  Off | Error | Warn | Info (default) | Debug | Trace
+    pub level: Level,
+    /// Max number of temp logfiles to retain
+    pub directory: Option<String>,
+    pub filename: Option<String>,
+    pub max_file_count: Option<i64>,
+    /// Max logfile size in MB
+    pub max_file_size: Option<usize>,
+}
+
+impl LoggingSettings {
+    pub fn new(mode: LogMode, level: Level) -> Self {
+        LoggingSettings {
+            mode,
+            level,
+            directory: None,
+            filename: None,
+            max_file_count: None,
+            max_file_size: None,
+        }
+    }
+
+    pub fn with_directory(mut self, directory: String) -> Self {
+        self.directory = Some(directory);
+        self
+    }
 }
 
 #[derive(serde::Deserialize, Clone)]

--- a/backend/service/src/test_utils.rs
+++ b/backend/service/src/test_utils.rs
@@ -62,6 +62,7 @@ pub fn get_test_settings(db_name: &str) -> Settings {
             host: "localhost".to_string(),
             database_name: String::from("dashboard"),
         },
+        logging: None,
     }
 }
 


### PR DESCRIPTION
<!-- IMPORTANT!
  - Every PR must reference an issue; this helps to explain the intent of the PR
 -->

Closes #173

# 👩🏻‍💻 What does this PR do?
 <!-- Explain the changes you made, and why they're needed. Add a screenshot if you've made any UI changes!  -->

This is a copy of the open-mSupply logging setup. 

It allows logging to the console and/or a log file.
By default it does both see `base.yaml`

# 🧪 How has/should this change been tested?
<!-- Explain how to setup for testing here if it is not already obvious, and how you've tested this PR. -->

Ideally should be tested on linux and windows.
Check that `max_file_count` and `max_file_size` are working (not actually 100% sure how they are managed, copied from open-mSupply so hoping that they work!)

## 💌 Any notes for the reviewer?
<!-- eg. Do you have any specific questions for the reviewer? Is there a high risk/complicated change they should focus on? If there are any general areas of the codebase your changes might have have touched or could cause side effects to, mention them here.-->
Console logging won't show up on windows when running as a service, so we should setup the file based logging in this situation.

